### PR TITLE
Feature/pass state support 

### DIFF
--- a/src/StateMachine.ts
+++ b/src/StateMachine.ts
@@ -11,6 +11,7 @@ import { TaskState } from './typings/TaskState';
 import { LambdaExecutionError } from './error/LambdaExecutionError';
 import { PayloadTemplate } from './typings/InputOutputProcessing';
 import { JSONValue } from './typings/JSONValue';
+import { PassState } from './typings/PassState';
 
 type StateHandler = {
   [T in StateType]: () => Promise<void>;
@@ -73,7 +74,7 @@ export class StateMachine {
     this.stateHandlers = {
       Task: this.handleTaskState.bind(this),
       Map: () => Promise.resolve(),
-      Pass: () => Promise.resolve(),
+      Pass: this.handlePassState.bind(this),
       Wait: () => Promise.resolve(),
       Choice: () => Promise.resolve(),
       Succeed: () => Promise.resolve(),
@@ -245,6 +246,22 @@ export class StateMachine {
       }
 
       exit(1);
+    }
+  }
+
+  /**
+   * Handler for pass states.
+   *
+   * If the `Result` field is specified, copies `Result` into the current result.
+   * Else, copies the current input into the current result.
+   */
+  private async handlePassState() {
+    const state = this.currState as PassState;
+
+    if (state.Result) {
+      this.currResult = state.Result;
+    } else {
+      this.currResult = this.currInput;
     }
   }
 

--- a/src/typings/PassState.ts
+++ b/src/typings/PassState.ts
@@ -1,11 +1,12 @@
 import { BaseState } from './BaseState';
 import { CanHaveInputPath, CanHaveOutputPath, CanHaveParameters, CanHaveResultPath } from './InputOutputProcessing';
 import { IntermediateState } from './IntermediateState';
+import { JSONValue } from './JSONValue';
 import { TerminalState } from './TerminalState';
 
 interface BasePassState extends BaseState, CanHaveInputPath, CanHaveParameters, CanHaveResultPath, CanHaveOutputPath {
   Type: 'Pass';
-  Result?: unknown;
+  Result?: JSONValue;
 }
 
 export type PassState = (IntermediateState | TerminalState) & BasePassState;


### PR DESCRIPTION
Adds support for `Pass` states:

1. If the `Result` field is specified, copies the value in `Result` to the result
2. Else, copies the current input value into the result