### PR TITLE
Chore/bump bunchee v2.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "@types/picomatch": "^2.3.0",
         "@typescript-eslint/eslint-plugin": "^5.22.0",
         "@typescript-eslint/parser": "^5.22.0",
-        "bunchee": "^2.1.7",
+        "bunchee": "^2.2.0",
         "eslint": "^8.14.0",
         "eslint-config-prettier": "^8.5.0",
         "eslint-plugin-prettier": "^4.0.0",
@@ -3286,9 +3286,9 @@
       }
     },
     "node_modules/bunchee": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/bunchee/-/bunchee-2.1.7.tgz",
-      "integrity": "sha512-0eJxpWzCnuTTeEDDLrKhs5mr17j/Czx66St+ptr3r6OaIxtXL/cftPGjS+bVeypPTbqZ/EDdPbJ6sXYe58V2yg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/bunchee/-/bunchee-2.2.0.tgz",
+      "integrity": "sha512-lJY6bMIbNcSfBPUZ+6ZZPoqTKIPkl0fi+SL+DBDhWER1GOH14m6DTGLpa0MSEI3bo3TBUJ7TggQ/Gw7p76+nvQ==",
       "dev": true,
       "dependencies": {
         "@rollup/plugin-commonjs": "22.0.2",
@@ -9218,9 +9218,9 @@
       "dev": true
     },
     "bunchee": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/bunchee/-/bunchee-2.1.7.tgz",
-      "integrity": "sha512-0eJxpWzCnuTTeEDDLrKhs5mr17j/Czx66St+ptr3r6OaIxtXL/cftPGjS+bVeypPTbqZ/EDdPbJ6sXYe58V2yg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/bunchee/-/bunchee-2.2.0.tgz",
+      "integrity": "sha512-lJY6bMIbNcSfBPUZ+6ZZPoqTKIPkl0fi+SL+DBDhWER1GOH14m6DTGLpa0MSEI3bo3TBUJ7TggQ/Gw7p76+nvQ==",
       "dev": true,
       "requires": {
         "@rollup/plugin-commonjs": "22.0.2",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "scripts": {
     "test": "jest",
-    "build": "bunchee --target es2015 --minify src/main.ts",
+    "build": "bunchee --minify src/main.ts",
     "prettier": "prettier --write src/**/*.ts",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix"

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "@types/picomatch": "^2.3.0",
     "@typescript-eslint/eslint-plugin": "^5.22.0",
     "@typescript-eslint/parser": "^5.22.0",
-    "bunchee": "^2.1.7",
+    "bunchee": "^2.2.0",
     "eslint": "^8.14.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-prettier": "^4.0.0",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "@tsconfig/node16-strictest/tsconfig.json",
   "compilerOptions": {
     "outDir": "build",
-    "target": "ES6",
+    "target": "ES2015",
     "declaration": true,
     "noUncheckedIndexedAccess": false
   },


### PR DESCRIPTION
Bumps `bunchee` to version 2.2.0 to leverage using `target` from TSConfig: https://github.com/huozhi/bunchee/releases/tag/v2.2.0