### PR TITLE
Fix bug where `waitTimeOverrideOption` is not honored when passing 0

### DIFF
--- a/src/StateMachine.ts
+++ b/src/StateMachine.ts
@@ -358,7 +358,7 @@ export class StateMachine {
     const state = this.currState as WaitState;
     const waitTimeOverrideOption = options?.overrides?.waitTimeOverrides?.[this.currStateName];
 
-    if (waitTimeOverrideOption) {
+    if (waitTimeOverrideOption !== undefined) {
       // If the wait time override is set, sleep for the specified number of milliseconds
       await sleep(waitTimeOverrideOption);
       this.currResult = this.currInput;


### PR DESCRIPTION
Take the following example:

```js
const result = await stateMachine.run(input, {
  overrides: {
    waitTimeOverrides: {
      WaitState: 0,
    },
  },
});
```

If passing 0 as an override to `waitTimeOverrides`, the state machine should wait 0 milliseconds, effectively not waiting any time in the overridden wait state. However, this is not the actual behavior. Instead, the state machine will wait the entire time specified in the wait state.

This PR fixes that behavior.