### PR TITLE
Refactor 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ const stateMachine = new StateMachine(machineDefinition, { checkPaths: false });
 
 ### `async StateMachine.run(input[, options])`
 
-Executes the state machine with the given `input` parameter and returns the result of the execution.
+Runs the state machine with the given `input` parameter and returns the result of the execution. Each execution is independent of all others, meaning that you can concurrently call this method as many times as needed, without worrying about race conditions.
 
 It takes the following parameters:
 

--- a/src/StateMachine.ts
+++ b/src/StateMachine.ts
@@ -9,6 +9,7 @@ import type { ChoiceState } from './typings/ChoiceState';
 import type { SucceedState } from './typings/SucceedState';
 import type { FailState } from './typings/FailState';
 import type { RunOptions, StateHandler, ValidationOptions } from './typings/StateMachineImplementation';
+import type { ExecutionResult } from './typings/StateHandlers';
 import { TaskStateHandler } from './stateHandlers/TaskStateHandler';
 import { MapStateHandler } from './stateHandlers/MapStateHandler';
 import { PassStateHandler } from './stateHandlers/PassStateHandler';
@@ -23,42 +24,13 @@ import {
   processResultPath,
 } from './InputOutputProcessing';
 import aslValidator from 'asl-validator';
+import cloneDeep from 'lodash/cloneDeep.js';
 
 export class StateMachine {
   /**
-   * The name of the state currently being executed.
+   * The structure of the State Machine as represented by the Amazon States Language.
    */
-  private currStateName: string;
-
-  /**
-   * The current state being executed.
-   */
-  private currState: AllStates;
-
-  /**
-   * The unmodified input to the current state.
-   */
-  private rawInput: JSONValue;
-
-  /**
-   * The input that can be modified according to the `InputPath` and `Parameters` fields of the current state.
-   */
-  private currInput: JSONValue;
-
-  /**
-   * The result that can be modified according to the `ResultSelector`, `ResultPath` and `OutputPath` fields of the current state.
-   */
-  private currResult: JSONValue;
-
-  /**
-   * The context object of the state machine.
-   */
-  private context: Record<string, unknown>;
-
-  /**
-   * A map of all states defined in the state machine.
-   */
-  private readonly states: Record<string, AllStates>;
+  private readonly definition: StateMachineDefinition;
 
   /**
    * A map of functions to handle each type of state.
@@ -87,21 +59,15 @@ export class StateMachine {
       throw new Error(`State machine definition is invalid, see error(s) below:\n ${errorsText('\n')}`);
     }
 
-    this.states = definition.States;
-    this.currStateName = definition.StartAt;
-    this.currState = this.states[this.currStateName];
-    this.rawInput = {};
-    this.currInput = {};
-    this.currResult = null;
-    this.context = {};
+    this.definition = definition;
     this.stateHandlers = {
-      Task: this.handleTaskState.bind(this),
-      Map: this.handleMapState.bind(this),
-      Pass: this.handlePassState.bind(this),
-      Wait: this.handleWaitState.bind(this),
-      Choice: this.handleChoiceState.bind(this),
-      Succeed: this.handleSucceedState.bind(this),
-      Fail: this.handleFailState.bind(this),
+      Task: this.handleTaskState,
+      Map: this.handleMapState,
+      Pass: this.handlePassState,
+      Wait: this.handleWaitState,
+      Choice: this.handleChoiceState,
+      Succeed: this.handleSucceedState,
+      Fail: this.handleFailState,
     };
     this.validationOptions = validationOptions;
   }
@@ -112,64 +78,79 @@ export class StateMachine {
    * @param options Miscellaneous options to control certain behaviors of the execution.
    */
   async run(input: JSONValue, options?: RunOptions): Promise<JSONValue> {
-    this.rawInput = input;
-    this.currInput = input;
-
+    let currState = this.definition.States[this.definition.StartAt];
+    let currStateName = this.definition.StartAt;
+    let rawInput = cloneDeep(input);
+    let currInput = cloneDeep(input);
+    let currResult: JSONValue = null;
+    let nextState = '';
     let isEndState = false;
+    // eslint-disable-next-line prefer-const
+    let context: Record<string, unknown> = {};
+
     do {
-      this.currState = this.states[this.currStateName];
+      currInput = this.processInput(currState, currInput, context);
+      ({
+        stateResult: currResult,
+        nextState,
+        isEndState,
+        // @ts-expect-error Indexing `this.stateHandlers` by non-literal value produces a `never` type for the `stateDefinition` parameter of the handler being called
+      } = await this.stateHandlers[currState.Type](currState, currInput, context, currStateName, options));
+      currResult = this.processResult(currState, currResult, rawInput, context);
 
-      this.processInput();
+      rawInput = currResult;
+      currInput = currResult;
 
-      await this.stateHandlers[this.currState.Type](options);
-
-      this.processResult();
-
-      this.rawInput = this.currResult;
-      this.currInput = this.currResult;
-
-      if ('Next' in this.currState) {
-        this.currStateName = this.currState.Next;
-      }
-
-      if ('End' in this.currState || this.currState.Type === 'Succeed' || this.currState.Type === 'Fail') {
-        isEndState = true;
-      }
+      currState = this.definition.States[nextState];
+      currStateName = nextState;
     } while (!isEndState);
 
-    return this.currResult;
+    return currResult;
   }
 
   /**
    * Process the current input according to the `InputPath` and `Parameters` fields.
    */
-  private processInput(): void {
-    if ('InputPath' in this.currState) {
-      this.currInput = processInputPath(this.currState.InputPath, this.currInput, this.context);
+  private processInput(currentState: AllStates, input: JSONValue, context: Record<string, unknown>): JSONValue {
+    let processedInput = input;
+
+    if ('InputPath' in currentState) {
+      processedInput = processInputPath(currentState.InputPath, processedInput, context);
     }
 
-    if ('Parameters' in this.currState && this.currState.Type !== 'Map') {
+    if ('Parameters' in currentState && currentState.Type !== 'Map') {
       // `Parameters` field is handled differently in the `Map` state,
       // hence why we omit processing it here.
-      this.currInput = processPayloadTemplate(this.currState.Parameters, this.currInput, this.context);
+      processedInput = processPayloadTemplate(currentState.Parameters, processedInput, context);
     }
+
+    return processedInput;
   }
 
   /**
    * Process the current result according to the `ResultSelector`, `ResultPath` and `OutputPath` fields.
    */
-  private processResult(): void {
-    if ('ResultSelector' in this.currState) {
-      this.currResult = processPayloadTemplate(this.currState.ResultSelector, this.currResult, this.context);
+  private processResult(
+    currentState: AllStates,
+    result: JSONValue,
+    rawInput: JSONValue,
+    context: Record<string, unknown>
+  ): JSONValue {
+    let processedResult = result;
+
+    if ('ResultSelector' in currentState) {
+      processedResult = processPayloadTemplate(currentState.ResultSelector, processedResult, context);
     }
 
-    if ('ResultPath' in this.currState) {
-      this.currResult = processResultPath(this.currState.ResultPath, this.rawInput, this.currResult);
+    if ('ResultPath' in currentState) {
+      processedResult = processResultPath(currentState.ResultPath, rawInput, processedResult);
     }
 
-    if ('OutputPath' in this.currState) {
-      this.currResult = processOutputPath(this.currState.OutputPath, this.currResult, this.context);
+    if ('OutputPath' in currentState) {
+      processedResult = processOutputPath(currentState.OutputPath, processedResult, context);
     }
+
+    return processedResult;
   }
 
   /**
@@ -178,13 +159,19 @@ export class StateMachine {
    * Invokes the Lambda function specified in the `Resource` field
    * and sets the current result of the state machine to the value returned by the Lambda.
    */
-  private async handleTaskState(options?: RunOptions): Promise<void> {
-    const overrideFn = options?.overrides?.taskResourceLocalHandlers?.[this.currStateName];
+  private async handleTaskState(
+    stateDefinition: TaskState,
+    input: JSONValue,
+    context: Record<string, unknown>,
+    stateName: string,
+    options?: RunOptions
+  ): Promise<ExecutionResult> {
+    const overrideFn = options?.overrides?.taskResourceLocalHandlers?.[stateName];
 
-    const taskStateHandler = new TaskStateHandler(this.currState as TaskState);
-    const { stateResult } = await taskStateHandler.executeState(this.currInput, this.context, { overrideFn });
+    const taskStateHandler = new TaskStateHandler(stateDefinition);
+    const executionResult = await taskStateHandler.executeState(input, context, { overrideFn });
 
-    this.currResult = stateResult;
+    return executionResult;
   }
 
   /**
@@ -194,14 +181,20 @@ export class StateMachine {
    * by the `ItemsPath` field, and then processes each item by passing it
    * as the input to the state machine specified in the `Iterator` field.
    */
-  private async handleMapState(options?: RunOptions): Promise<void> {
-    const mapStateHandler = new MapStateHandler(this.currState as MapState);
-    const { stateResult } = await mapStateHandler.executeState(this.currInput, this.context, {
+  private async handleMapState(
+    stateDefinition: MapState,
+    input: JSONValue,
+    context: Record<string, unknown>,
+    stateName: string,
+    options?: RunOptions
+  ): Promise<ExecutionResult> {
+    const mapStateHandler = new MapStateHandler(stateDefinition);
+    const executionResult = await mapStateHandler.executeState(input, context, {
       validationOptions: this.validationOptions,
       runOptions: options,
     });
 
-    this.currResult = stateResult;
+    return executionResult;
   }
 
   /**
@@ -210,12 +203,19 @@ export class StateMachine {
    * If the `Result` field is specified, copies `Result` into the current result.
    * Else, copies the current input into the current result.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  private async handlePassState(options?: RunOptions): Promise<void> {
-    const passStateHandler = new PassStateHandler(this.currState as PassState);
-    const { stateResult } = await passStateHandler.executeState(this.currInput, this.context);
+  private async handlePassState(
+    stateDefinition: PassState,
+    input: JSONValue,
+    context: Record<string, unknown>,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    stateName: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    options?: RunOptions
+  ): Promise<ExecutionResult> {
+    const passStateHandler = new PassStateHandler(stateDefinition);
+    const executionResult = await passStateHandler.executeState(input, context);
 
-    this.currResult = stateResult;
+    return executionResult;
   }
 
   /**
@@ -224,15 +224,21 @@ export class StateMachine {
    * Pauses the state machine execution for a certain amount of time
    * based on one of the `Seconds`, `Timestamp`, `SecondsPath` or `TimestampPath` fields.
    */
-  private async handleWaitState(options?: RunOptions): Promise<void> {
-    const waitTimeOverrideOption = options?.overrides?.waitTimeOverrides?.[this.currStateName];
+  private async handleWaitState(
+    stateDefinition: WaitState,
+    input: JSONValue,
+    context: Record<string, unknown>,
+    stateName: string,
+    options?: RunOptions
+  ): Promise<ExecutionResult> {
+    const waitTimeOverrideOption = options?.overrides?.waitTimeOverrides?.[stateName];
 
-    const waitStateHandler = new WaitStateHandler(this.currState as WaitState);
-    const { stateResult } = await waitStateHandler.executeState(this.currInput, this.context, {
+    const waitStateHandler = new WaitStateHandler(stateDefinition);
+    const executionResult = await waitStateHandler.executeState(input, context, {
       waitTimeOverrideOption,
     });
 
-    this.currResult = stateResult;
+    return executionResult;
   }
 
   /**
@@ -249,13 +255,19 @@ export class StateMachine {
    * If no rule matches and the `Default` field is not specified, throws a
    * States.NoChoiceMatched error.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  private async handleChoiceState(options?: RunOptions): Promise<void> {
-    const choiceStateHandler = new ChoiceStateHandler(this.currState as ChoiceState);
-    const { stateResult, nextState } = await choiceStateHandler.executeState(this.currInput, this.context);
+  private async handleChoiceState(
+    stateDefinition: ChoiceState,
+    input: JSONValue,
+    context: Record<string, unknown>,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    stateName: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    options?: RunOptions
+  ): Promise<ExecutionResult> {
+    const choiceStateHandler = new ChoiceStateHandler(stateDefinition);
+    const executionResult = await choiceStateHandler.executeState(input, context);
 
-    this.currResult = stateResult;
-    this.currStateName = nextState!;
+    return executionResult;
   }
 
   /**
@@ -263,12 +275,19 @@ export class StateMachine {
    *
    * Ends the state machine execution successfully.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  private async handleSucceedState(options?: RunOptions): Promise<void> {
-    const succeedStateHandler = new SucceedStateHandler(this.currState as SucceedState);
-    const { stateResult } = await succeedStateHandler.executeState(this.currInput, this.context);
+  private async handleSucceedState(
+    stateDefinition: SucceedState,
+    input: JSONValue,
+    context: Record<string, unknown>,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    stateName: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    options?: RunOptions
+  ): Promise<ExecutionResult> {
+    const succeedStateHandler = new SucceedStateHandler(stateDefinition);
+    const executionResult = await succeedStateHandler.executeState(input, context);
 
-    this.currResult = stateResult;
+    return executionResult;
   }
 
   /**
@@ -276,11 +295,18 @@ export class StateMachine {
    *
    * Ends the state machine execution and marks it as a failure.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  private async handleFailState(options?: RunOptions): Promise<void> {
-    const failStateHandler = new FailStateHandler(this.currState as FailState);
-    const { stateResult } = await failStateHandler.executeState(this.currInput, this.context);
+  private async handleFailState(
+    stateDefinition: FailState,
+    input: JSONValue,
+    context: Record<string, unknown>,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    stateName: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    options?: RunOptions
+  ): Promise<ExecutionResult> {
+    const failStateHandler = new FailStateHandler(stateDefinition);
+    const executionResult = await failStateHandler.executeState(input, context);
 
-    this.currResult = stateResult;
+    return executionResult;
   }
 }

--- a/src/StateMachine.ts
+++ b/src/StateMachine.ts
@@ -33,9 +33,9 @@ export class StateMachine {
   private readonly definition: StateMachineDefinition;
 
   /**
-   * A map of functions to handle each type of state.
+   * A map of functions to execute each type of state.
    */
-  private readonly stateHandlers: StateHandler;
+  private readonly stateExecutors: StateHandler;
 
   /**
    * Options to control whether to apply certain validations to the state machine definition.
@@ -60,14 +60,14 @@ export class StateMachine {
     }
 
     this.definition = definition;
-    this.stateHandlers = {
-      Task: this.handleTaskState,
-      Map: this.handleMapState,
-      Pass: this.handlePassState,
-      Wait: this.handleWaitState,
-      Choice: this.handleChoiceState,
-      Succeed: this.handleSucceedState,
-      Fail: this.handleFailState,
+    this.stateExecutors = {
+      Task: this.executeTaskState,
+      Map: this.executeMapState,
+      Pass: this.executePassState,
+      Wait: this.executeWaitState,
+      Choice: this.executeChoiceState,
+      Succeed: this.executeSucceedState,
+      Fail: this.executeFailState,
     };
     this.validationOptions = validationOptions;
   }
@@ -95,7 +95,7 @@ export class StateMachine {
         nextState,
         isEndState,
         // @ts-expect-error Indexing `this.stateHandlers` by non-literal value produces a `never` type for the `stateDefinition` parameter of the handler being called
-      } = await this.stateHandlers[currState.Type](currState, currInput, context, currStateName, options));
+      } = await this.stateExecutors[currState.Type](currState, currInput, context, currStateName, options));
       currResult = this.processResult(currState, currResult, rawInput, context);
 
       rawInput = currResult;
@@ -159,7 +159,7 @@ export class StateMachine {
    * Invokes the Lambda function specified in the `Resource` field
    * and sets the current result of the state machine to the value returned by the Lambda.
    */
-  private async handleTaskState(
+  private async executeTaskState(
     stateDefinition: TaskState,
     input: JSONValue,
     context: Record<string, unknown>,
@@ -181,7 +181,7 @@ export class StateMachine {
    * by the `ItemsPath` field, and then processes each item by passing it
    * as the input to the state machine specified in the `Iterator` field.
    */
-  private async handleMapState(
+  private async executeMapState(
     stateDefinition: MapState,
     input: JSONValue,
     context: Record<string, unknown>,
@@ -203,7 +203,7 @@ export class StateMachine {
    * If the `Result` field is specified, copies `Result` into the current result.
    * Else, copies the current input into the current result.
    */
-  private async handlePassState(
+  private async executePassState(
     stateDefinition: PassState,
     input: JSONValue,
     context: Record<string, unknown>,
@@ -224,7 +224,7 @@ export class StateMachine {
    * Pauses the state machine execution for a certain amount of time
    * based on one of the `Seconds`, `Timestamp`, `SecondsPath` or `TimestampPath` fields.
    */
-  private async handleWaitState(
+  private async executeWaitState(
     stateDefinition: WaitState,
     input: JSONValue,
     context: Record<string, unknown>,
@@ -255,7 +255,7 @@ export class StateMachine {
    * If no rule matches and the `Default` field is not specified, throws a
    * States.NoChoiceMatched error.
    */
-  private async handleChoiceState(
+  private async executeChoiceState(
     stateDefinition: ChoiceState,
     input: JSONValue,
     context: Record<string, unknown>,
@@ -275,7 +275,7 @@ export class StateMachine {
    *
    * Ends the state machine execution successfully.
    */
-  private async handleSucceedState(
+  private async executeSucceedState(
     stateDefinition: SucceedState,
     input: JSONValue,
     context: Record<string, unknown>,
@@ -295,7 +295,7 @@ export class StateMachine {
    *
    * Ends the state machine execution and marks it as a failure.
    */
-  private async handleFailState(
+  private async executeFailState(
     stateDefinition: FailState,
     input: JSONValue,
     context: Record<string, unknown>,

--- a/src/stateHandlers/BaseStateHandler.ts
+++ b/src/stateHandlers/BaseStateHandler.ts
@@ -11,12 +11,14 @@ abstract class BaseStateHandler<T extends BaseState | IntermediateState | Termin
     this.stateDefinition = stateDefinition;
   }
 
-  protected buildExecutionResult(stateResult: JSONValue) {
-    const executionResult: ExecutionResult = { stateResult };
+  protected buildExecutionResult(stateResult: JSONValue): ExecutionResult {
+    const executionResult: ExecutionResult = { stateResult, nextState: '', isEndState: false };
 
     if ('Next' in this.stateDefinition) {
       executionResult.nextState = this.stateDefinition.Next;
-    } else if ('End' in this.stateDefinition) {
+    }
+
+    if ('End' in this.stateDefinition) {
       executionResult.isEndState = this.stateDefinition.End;
     }
 

--- a/src/stateHandlers/BaseStateHandler.ts
+++ b/src/stateHandlers/BaseStateHandler.ts
@@ -2,12 +2,7 @@ import type { IntermediateState } from '../typings/IntermediateState';
 import type { TerminalState } from '../typings/TerminalState';
 import type { JSONValue } from '../typings/JSONValue';
 import type { BaseState } from '../typings/BaseState';
-
-export interface ExecutionResult {
-  stateResult: JSONValue;
-  nextState?: string;
-  isEndState?: boolean;
-}
+import type { ExecutionResult } from '../typings/StateHandlers';
 
 abstract class BaseStateHandler<T extends BaseState | IntermediateState | TerminalState> {
   protected stateDefinition: T;

--- a/src/stateHandlers/ChoiceStateHandler.ts
+++ b/src/stateHandlers/ChoiceStateHandler.ts
@@ -1,10 +1,9 @@
 import type { JSONValue } from '../typings/JSONValue';
 import type { ChoiceState, ChoiceRuleWithoutNext } from '../typings/ChoiceState';
-import { BaseStateHandler, ExecutionResult } from './BaseStateHandler';
+import type { ChoiceStateHandlerOptions, ExecutionResult } from '../typings/StateHandlers';
+import { BaseStateHandler } from './BaseStateHandler';
 import { jsonPathQuery } from '../JsonPath';
 import wcmatch from 'wildcard-match';
-
-type ChoiceStateHandlerOptions = Record<string, unknown>;
 
 class ChoiceStateHandler extends BaseStateHandler<ChoiceState> {
   constructor(stateDefinition: ChoiceState) {

--- a/src/stateHandlers/ChoiceStateHandler.ts
+++ b/src/stateHandlers/ChoiceStateHandler.ts
@@ -261,12 +261,12 @@ class ChoiceStateHandler extends BaseStateHandler<ChoiceState> {
     for (const choice of state.Choices) {
       const choiceIsMatch = this.testChoiceRule(choice, input);
       if (choiceIsMatch) {
-        return { stateResult: input, nextState: choice.Next };
+        return { stateResult: input, nextState: choice.Next, isEndState: false };
       }
     }
 
     if (state.Default) {
-      return { stateResult: input, nextState: state.Default };
+      return { stateResult: input, nextState: state.Default, isEndState: false };
     }
 
     // TODO: Throw States.NoChoiceMatched error here because all choices failed to match and no `Default` field was specified.

--- a/src/stateHandlers/FailStateHandler.ts
+++ b/src/stateHandlers/FailStateHandler.ts
@@ -1,8 +1,7 @@
 import type { JSONValue } from '../typings/JSONValue';
 import type { FailState } from '../typings/FailState';
-import { BaseStateHandler, ExecutionResult } from './BaseStateHandler';
-
-type FailStateHandlerOptions = Record<string, unknown>;
+import type { ExecutionResult, FailStateHandlerOptions } from '../typings/StateHandlers';
+import { BaseStateHandler } from './BaseStateHandler';
 
 class FailStateHandler extends BaseStateHandler<FailState> {
   constructor(stateDefinition: FailState) {

--- a/src/stateHandlers/FailStateHandler.ts
+++ b/src/stateHandlers/FailStateHandler.ts
@@ -16,7 +16,7 @@ class FailStateHandler extends BaseStateHandler<FailState> {
     options?: FailStateHandlerOptions
   ): Promise<ExecutionResult> {
     // TODO: Implement behavior of fail state
-    return { stateResult: input, isEndState: true };
+    return { stateResult: input, nextState: '', isEndState: true };
   }
 }
 

--- a/src/stateHandlers/MapStateHandler.ts
+++ b/src/stateHandlers/MapStateHandler.ts
@@ -1,16 +1,11 @@
-import type { RunOptions, ValidationOptions } from '../typings/StateMachineImplementation';
 import type { MapState } from '../typings/MapState';
 import type { JSONValue } from '../typings/JSONValue';
-import { BaseStateHandler, ExecutionResult } from './BaseStateHandler';
+import type { ExecutionResult, MapStateHandlerOptions } from '../typings/StateHandlers';
+import { BaseStateHandler } from './BaseStateHandler';
 import { StateMachine } from '../StateMachine';
 import { jsonPathQuery } from '../JsonPath';
 import { processPayloadTemplate } from '../InputOutputProcessing';
 import pLimit from 'p-limit';
-
-type MapStateHandlerOptions = {
-  validationOptions: ValidationOptions | undefined;
-  runOptions: RunOptions | undefined;
-};
 
 class MapStateHandler extends BaseStateHandler<MapState> {
   constructor(stateDefinition: MapState) {

--- a/src/stateHandlers/PassStateHandler.ts
+++ b/src/stateHandlers/PassStateHandler.ts
@@ -1,8 +1,7 @@
 import type { JSONValue } from '../typings/JSONValue';
 import type { PassState } from '../typings/PassState';
-import { BaseStateHandler, ExecutionResult } from './BaseStateHandler';
-
-type PassStateHandlerOptions = Record<string, unknown>;
+import type { ExecutionResult, PassStateHandlerOptions } from '../typings/StateHandlers';
+import { BaseStateHandler } from './BaseStateHandler';
 
 class PassStateHandler extends BaseStateHandler<PassState> {
   constructor(stateDefinition: PassState) {

--- a/src/stateHandlers/SucceedStateHandler.ts
+++ b/src/stateHandlers/SucceedStateHandler.ts
@@ -1,8 +1,7 @@
 import type { JSONValue } from '../typings/JSONValue';
+import type { ExecutionResult, SucceedStateHandlerOptions } from '../typings/StateHandlers';
 import type { SucceedState } from '../typings/SucceedState';
-import { BaseStateHandler, ExecutionResult } from './BaseStateHandler';
-
-type SucceedStateHandlerOptions = Record<string, unknown>;
+import { BaseStateHandler } from './BaseStateHandler';
 
 class SucceedStateHandler extends BaseStateHandler<SucceedState> {
   constructor(stateDefinition: SucceedState) {

--- a/src/stateHandlers/SucceedStateHandler.ts
+++ b/src/stateHandlers/SucceedStateHandler.ts
@@ -15,7 +15,7 @@ class SucceedStateHandler extends BaseStateHandler<SucceedState> {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     options?: SucceedStateHandlerOptions
   ): Promise<ExecutionResult> {
-    return { stateResult: input, isEndState: true };
+    return { stateResult: input, nextState: '', isEndState: true };
   }
 }
 

--- a/src/stateHandlers/TaskStateHandler.ts
+++ b/src/stateHandlers/TaskStateHandler.ts
@@ -1,12 +1,9 @@
 import type { TaskState } from '../typings/TaskState';
 import type { JSONValue } from '../typings/JSONValue';
-import { BaseStateHandler, ExecutionResult } from './BaseStateHandler';
+import type { ExecutionResult, TaskStateHandlerOptions } from '../typings/StateHandlers';
+import { BaseStateHandler } from './BaseStateHandler';
 import { LambdaClient } from '../aws/LambdaClient';
 import { LambdaExecutionError } from '../error/LambdaExecutionError';
-
-type TaskStateHandlerOptions = {
-  overrideFn: ((input: JSONValue) => Promise<JSONValue>) | undefined;
-};
 
 class TaskStateHandler extends BaseStateHandler<TaskState> {
   constructor(stateDefinition: TaskState) {

--- a/src/stateHandlers/WaitStateHandler.ts
+++ b/src/stateHandlers/WaitStateHandler.ts
@@ -1,12 +1,9 @@
 import type { JSONValue } from '../typings/JSONValue';
 import type { WaitState } from '../typings/WaitState';
-import { BaseStateHandler, ExecutionResult } from './BaseStateHandler';
+import type { ExecutionResult, WaitStateHandlerOptions } from '../typings/StateHandlers';
+import { BaseStateHandler } from './BaseStateHandler';
 import { jsonPathQuery } from '../JsonPath';
 import { sleep } from '../util';
-
-type WaitStateHandlerOptions = {
-  waitTimeOverrideOption: number | undefined;
-};
 
 class WaitStateHandler extends BaseStateHandler<WaitState> {
   constructor(stateDefinition: WaitState) {

--- a/src/typings/JSONValue.ts
+++ b/src/typings/JSONValue.ts
@@ -1,1 +1,1 @@
-export type JSONValue = null | boolean | number | string | object | any[];
+export type JSONValue = null | boolean | number | string | object | JSONValue[];

--- a/src/typings/StateHandlers.ts
+++ b/src/typings/StateHandlers.ts
@@ -3,8 +3,8 @@ import type { RunOptions, ValidationOptions } from './StateMachineImplementation
 
 export interface ExecutionResult {
   stateResult: JSONValue;
-  nextState?: string;
-  isEndState?: boolean;
+  nextState: string;
+  isEndState: boolean;
 }
 
 export type TaskStateHandlerOptions = {

--- a/src/typings/StateHandlers.ts
+++ b/src/typings/StateHandlers.ts
@@ -1,0 +1,29 @@
+import type { JSONValue } from './JSONValue';
+import type { RunOptions, ValidationOptions } from './StateMachineImplementation';
+
+export interface ExecutionResult {
+  stateResult: JSONValue;
+  nextState?: string;
+  isEndState?: boolean;
+}
+
+export type TaskStateHandlerOptions = {
+  overrideFn: ((input: JSONValue) => Promise<JSONValue>) | undefined;
+};
+
+export type MapStateHandlerOptions = {
+  validationOptions: ValidationOptions | undefined;
+  runOptions: RunOptions | undefined;
+};
+
+export type PassStateHandlerOptions = Record<string, unknown>;
+
+export type WaitStateHandlerOptions = {
+  waitTimeOverrideOption: number | undefined;
+};
+
+export type ChoiceStateHandlerOptions = Record<string, unknown>;
+
+export type SucceedStateHandlerOptions = Record<string, unknown>;
+
+export type FailStateHandlerOptions = Record<string, unknown>;

--- a/src/typings/StateMachineImplementation.ts
+++ b/src/typings/StateMachineImplementation.ts
@@ -1,7 +1,9 @@
-import type { StateType } from './StateType';
+import type { AllStates } from './AllStates';
+import type { JSONValue } from './JSONValue';
+import type { ExecutionResult } from './StateHandlers';
 
 type TaskStateResourceLocalHandler = {
-  [taskStateName: string]: (...args: any) => any;
+  [taskStateName: string]: (input: JSONValue) => Promise<JSONValue>;
 };
 
 type WaitStateTimeOverride = {
@@ -18,7 +20,13 @@ export interface RunOptions {
 }
 
 export type StateHandler = {
-  [T in StateType]: (options?: RunOptions) => Promise<void>;
+  [T in AllStates as T['Type']]: (
+    stateDefinition: T,
+    input: JSONValue,
+    context: Record<string, unknown>,
+    stateName: string,
+    options?: RunOptions
+  ) => Promise<ExecutionResult>;
 };
 
 export interface ValidationOptions {

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -3,7 +3,7 @@
  * @param value The value to test if it's a plain object or not.
  * @returns `true` if `value` is a plain object, `false` if not.
  */
-export function isPlainObj(value: any): boolean {
+export function isPlainObj(value: unknown): boolean {
   return !!value && Object.getPrototypeOf(value) === Object.prototype;
 }
 


### PR DESCRIPTION
Allow calling `StateMachine.run()` multiple times independently by getting rid of mutable members in the `StateMachine` class