### PR TITLE
Pass `validationOptions` to MapStateHandler as option param

### DIFF
--- a/src/StateMachine.ts
+++ b/src/StateMachine.ts
@@ -99,6 +99,7 @@ export class StateMachine {
     });
 
     const executionResult = this.execute(input, {
+      validationOptions: this.validationOptions,
       runOptions: options,
       abortSignal: abortController.signal,
     });
@@ -227,7 +228,7 @@ export class StateMachine {
   ): Promise<ExecutionResult> {
     const mapStateHandler = new MapStateHandler(stateDefinition);
     const executionResult = await mapStateHandler.executeState(input, context, {
-      validationOptions: this.validationOptions,
+      validationOptions: options.validationOptions,
       runOptions: options.runOptions,
     });
 

--- a/src/typings/StateMachineImplementation.ts
+++ b/src/typings/StateMachineImplementation.ts
@@ -15,12 +15,18 @@ interface Overrides {
   waitTimeOverrides?: WaitStateTimeOverride;
 }
 
+export interface ValidationOptions {
+  readonly checkPaths?: boolean;
+  readonly checkArn?: boolean;
+}
+
 export interface RunOptions {
   overrides?: Overrides;
   noThrowOnAbort?: boolean;
 }
 
 export interface ExecuteOptions {
+  validationOptions: ValidationOptions | undefined;
   runOptions: RunOptions | undefined;
   abortSignal: AbortSignal;
 }
@@ -34,8 +40,3 @@ export type StateExecutors = {
     options: ExecuteOptions
   ) => Promise<ExecutionResult>;
 };
-
-export interface ValidationOptions {
-  readonly checkPaths?: boolean;
-  readonly checkArn?: boolean;
-}


### PR DESCRIPTION
Fixes bug where `StateMachine` instances created in `MapStateHandler` didn't honor `validationOptions` set in parent state machine