### PR TITLE
Refactor 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AWS Local Step Functions
 
-A Node.js implementation of the [Amazon States Language specification](https://states-language.net/spec.html).
+A TypeScript implementation of the [Amazon States Language specification](https://states-language.net/spec.html).
 
 This package lets you run AWS Step Functions locally on your machine!
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,10 @@
+# Examples
+
+Here you can find some useful examples demonstrating specific usages of AWS Local Step Functions.
+
+- [abort-execution-without-throwing](./abort-execution-without-throwing.js): Abort a running execution without throwing an error.
+- [abort-execution](./abort-execution.js): Abort a running execution.
+- [check-for-execution-failure](./check-for-execution-failure.js): Check if execution failed and catch error.
+- [disable-state-machine-validation](./disable-state-machine-validation.js): Disable ARN and/or JSONPath validations when instantiating a new `StateMachine` object.
+- [task-state-local-override](./task-state-local-override.js): Override the default action for a `Task` state, so that instead of invoking the Lambda specified in the `Resource` field, it runs a local function. This allows running state machines completely locally.
+- [wait-state-local-override](./wait-state-local-override.js): Override the wait duration of a `Wait` state so that instead of waiting the duration specified in the `Seconds`, `Timestamp`, `SecondsPath`, `TimestampPath` fields, it waits for a specified number of milliseconds.

--- a/examples/check-for-execution-failure.js
+++ b/examples/check-for-execution-failure.js
@@ -1,0 +1,34 @@
+import { StateMachine, ExecutionError } from 'aws-local-stepfunctions';
+
+const machineDefinition = {
+  StartAt: 'MapState',
+  States: {
+    MapState: {
+      Type: 'Map',
+      Iterator: {
+        StartAt: 'Success',
+        States: {
+          Success: {
+            Type: 'Succeed',
+          },
+        },
+      },
+      End: true,
+    },
+  },
+};
+
+const stateMachine = new StateMachine(machineDefinition);
+const myInput = 'this is not an array';
+const execution = stateMachine.run(myInput);
+
+try {
+  // Execution fails because Map state expects an array as input
+  const result = await execution.result;
+  console.log(result);
+} catch (error) {
+  // When execution fails, type of error is `ExecutionError`
+  if (error instanceof ExecutionError) {
+    console.error('The execution has failed:', error);
+  }
+}

--- a/src/stateMachine/InputOutputProcessing.ts
+++ b/src/stateMachine/InputOutputProcessing.ts
@@ -1,5 +1,6 @@
 import type { PayloadTemplate } from '../typings/InputOutputProcessing';
 import type { JSONValue } from '../typings/JSONValue';
+import type { Context } from '../typings/Context';
 import { isPlainObj } from '../util';
 import { jsonPathQuery } from './JsonPath';
 import { StatesResultPathMatchFailureError } from '../error/predefined/StatesResultPathMatchFailureError';
@@ -13,7 +14,7 @@ import set from 'lodash/set.js';
  * * If `InputPath` is `null`, returns an empty object (`{}`).
  * * If `InputPath` is a string, it's considered a JSONPath and the selected portion of the current input is returned.
  */
-function processInputPath(path: string | null | undefined, input: JSONValue, context?: JSONValue): JSONValue {
+function processInputPath(path: string | null | undefined, input: JSONValue, context?: Context): JSONValue {
   if (path === undefined) {
     return input;
   }
@@ -32,11 +33,7 @@ function processInputPath(path: string | null | undefined, input: JSONValue, con
  * @param context The context object to evaluate, if the path expression starts with `$$`.
  * @returns The processed payload template.
  */
-function processPayloadTemplate(
-  payloadTemplate: PayloadTemplate,
-  json: JSONValue,
-  context?: JSONValue
-): PayloadTemplate {
+function processPayloadTemplate(payloadTemplate: PayloadTemplate, json: JSONValue, context?: Context): PayloadTemplate {
   const resolvedProperties = Object.entries(payloadTemplate).map(([key, value]) => {
     let sanitizedKey = key;
     let resolvedValue = value;
@@ -92,7 +89,7 @@ function processResultPath(path: string | null | undefined, rawInput: JSONValue,
  * * If `OutputPath` is `null`, returns an empty object (`{}`).
  * * If `OutputPath` is a string, it's considered a JSONPath and the selected portion of the current result is returned.
  */
-function processOutputPath(path: string | null | undefined, result: JSONValue, context?: JSONValue): JSONValue {
+function processOutputPath(path: string | null | undefined, result: JSONValue, context?: Context): JSONValue {
   if (path === undefined) {
     return result;
   }

--- a/src/stateMachine/InputOutputProcessing.ts
+++ b/src/stateMachine/InputOutputProcessing.ts
@@ -75,7 +75,7 @@ function processResultPath(path: string | null | undefined, rawInput: JSONValue,
   const sanitizedPath = path.replace('$.', '');
 
   if (isPlainObj(rawInput)) {
-    const clonedRawInput = cloneDeep(rawInput) as object;
+    const clonedRawInput = cloneDeep(rawInput);
     return set(clonedRawInput, sanitizedPath, result);
   }
 

--- a/src/stateMachine/JsonPath.ts
+++ b/src/stateMachine/JsonPath.ts
@@ -1,4 +1,5 @@
 import type { JSONValue } from '../typings/JSONValue';
+import type { Context } from '../typings/Context';
 import { JSONPath as jp } from 'jsonpath-plus';
 
 /**
@@ -8,7 +9,7 @@ import { JSONPath as jp } from 'jsonpath-plus';
  * @param context The context object to evaluate, if the path expression starts with `$$`.
  * @returns The value of the property that was queried for, if found. Otherwise returns `undefined`.
  */
-function jsonPathQuery<T>(pathExpression: string, json: JSONValue, context?: JSONValue): T {
+function jsonPathQuery<T>(pathExpression: string, json: JSONValue, context?: Context): T {
   // If the expression starts with double `$$`, evaluate the path in the context object.
   if (pathExpression.startsWith('$$')) {
     return jp({ path: pathExpression.slice(1), json: context ?? null, wrap: false });

--- a/src/stateMachine/StateExecutor.ts
+++ b/src/stateMachine/StateExecutor.ts
@@ -128,7 +128,7 @@ export class StateExecutor {
       // Handle `Retry` logic
       const { shouldRetry, waitTimeBeforeRetry } = this.shouldRetry(error as RuntimeError);
       if (shouldRetry && waitTimeBeforeRetry) {
-        await sleep(waitTimeBeforeRetry);
+        await sleep(waitTimeBeforeRetry, options.abortSignal);
         return this.execute(input, context, options);
       }
 

--- a/src/stateMachine/StateExecutor.ts
+++ b/src/stateMachine/StateExecutor.ts
@@ -12,6 +12,7 @@ import type { ChoiceState } from '../typings/ChoiceState';
 import type { FailState } from '../typings/FailState';
 import type { SucceedState } from '../typings/SucceedState';
 import type { RuntimeError } from '../error/RuntimeError';
+import type { Context } from '../typings/Context';
 import {
   processInputPath,
   processOutputPath,
@@ -101,7 +102,7 @@ export class StateExecutor {
   /**
    * Execute the current state.
    */
-  async execute(input: JSONValue, context: Record<string, unknown>, options: ExecuteOptions): Promise<ExecutionResult> {
+  async execute(input: JSONValue, context: Context, options: ExecuteOptions): Promise<ExecutionResult> {
     const rawInput = cloneDeep(input);
 
     try {
@@ -144,7 +145,7 @@ export class StateExecutor {
   /**
    * Process the current input according to the `InputPath` and `Parameters` fields.
    */
-  private processInput(input: JSONValue, context: Record<string, unknown>): JSONValue {
+  private processInput(input: JSONValue, context: Context): JSONValue {
     let processedInput = input;
 
     if ('InputPath' in this.stateDefinition) {
@@ -163,7 +164,7 @@ export class StateExecutor {
   /**
    * Process the current result according to the `ResultSelector`, `ResultPath` and `OutputPath` fields.
    */
-  private processResult(result: JSONValue, rawInput: JSONValue, context: Record<string, unknown>): JSONValue {
+  private processResult(result: JSONValue, rawInput: JSONValue, context: Context): JSONValue {
     let processedResult = result;
 
     if ('ResultSelector' in this.stateDefinition) {
@@ -265,7 +266,7 @@ export class StateExecutor {
   private async executeTaskState(
     stateDefinition: TaskState,
     input: JSONValue,
-    context: Record<string, unknown>,
+    context: Context,
     stateName: string,
     options: ExecuteOptions
   ): Promise<ExecutionResult> {
@@ -287,7 +288,7 @@ export class StateExecutor {
   private async executeMapState(
     stateDefinition: MapState,
     input: JSONValue,
-    context: Record<string, unknown>,
+    context: Context,
     stateName: string,
     options: ExecuteOptions
   ): Promise<ExecutionResult> {
@@ -309,7 +310,7 @@ export class StateExecutor {
   private async executePassState(
     stateDefinition: PassState,
     input: JSONValue,
-    context: Record<string, unknown>,
+    context: Context,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     stateName: string,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -330,7 +331,7 @@ export class StateExecutor {
   private async executeWaitState(
     stateDefinition: WaitState,
     input: JSONValue,
-    context: Record<string, unknown>,
+    context: Context,
     stateName: string,
     options: ExecuteOptions
   ): Promise<ExecutionResult> {
@@ -363,7 +364,7 @@ export class StateExecutor {
   private async executeChoiceState(
     stateDefinition: ChoiceState,
     input: JSONValue,
-    context: Record<string, unknown>,
+    context: Context,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     stateName: string,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -383,7 +384,7 @@ export class StateExecutor {
   private async executeSucceedState(
     stateDefinition: SucceedState,
     input: JSONValue,
-    context: Record<string, unknown>,
+    context: Context,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     stateName: string,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -403,7 +404,7 @@ export class StateExecutor {
   private async executeFailState(
     stateDefinition: FailState,
     input: JSONValue,
-    context: Record<string, unknown>,
+    context: Context,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     stateName: string,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/stateMachine/StateMachine.ts
+++ b/src/stateMachine/StateMachine.ts
@@ -1,6 +1,7 @@
 import type { StateMachineDefinition } from '../typings/StateMachineDefinition';
 import type { JSONValue } from '../typings/JSONValue';
 import type { ExecuteOptions, RunOptions, ValidationOptions } from '../typings/StateMachineImplementation';
+import type { Context } from '../typings/Context';
 import { ExecutionAbortedError } from '../error/ExecutionAbortedError';
 import { ExecutionError } from '../error/ExecutionError';
 import { StateExecutor } from './StateExecutor';
@@ -87,7 +88,7 @@ export class StateMachine {
     let nextState = '';
     let isEndState = false;
     // eslint-disable-next-line prefer-const
-    let context: Record<string, unknown> = {};
+    let context: Context = {};
 
     try {
       do {

--- a/src/stateMachine/stateActions/BaseStateAction.ts
+++ b/src/stateMachine/stateActions/BaseStateAction.ts
@@ -3,6 +3,7 @@ import type { TerminalState } from '../../typings/TerminalState';
 import type { JSONValue } from '../../typings/JSONValue';
 import type { BaseState } from '../../typings/BaseState';
 import type { ExecutionResult } from '../../typings/StateActions';
+import type { Context } from '../../typings/Context';
 
 abstract class BaseStateAction<T extends BaseState | IntermediateState | TerminalState> {
   protected stateDefinition: T;
@@ -25,11 +26,7 @@ abstract class BaseStateAction<T extends BaseState | IntermediateState | Termina
     return executionResult;
   }
 
-  abstract execute(
-    input: JSONValue,
-    context: Record<string, unknown>,
-    options?: Record<string, unknown>
-  ): Promise<ExecutionResult>;
+  abstract execute(input: JSONValue, context: Context, options?: Record<string, unknown>): Promise<ExecutionResult>;
 }
 
 export { BaseStateAction };

--- a/src/stateMachine/stateActions/ChoiceStateAction.ts
+++ b/src/stateMachine/stateActions/ChoiceStateAction.ts
@@ -1,6 +1,7 @@
 import type { JSONValue } from '../../typings/JSONValue';
 import type { ChoiceState, ChoiceRuleWithoutNext } from '../../typings/ChoiceState';
 import type { ChoiceStateActionOptions, ExecutionResult } from '../../typings/StateActions';
+import type { Context } from '../../typings/Context';
 import { BaseStateAction } from './BaseStateAction';
 import { jsonPathQuery } from '../JsonPath';
 import { StatesNoChoiceMatchedError } from '../../error/predefined/StatesNoChoiceMatchedError';
@@ -253,7 +254,7 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
   override async execute(
     input: JSONValue,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    context: Record<string, unknown>,
+    context: Context,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     options?: ChoiceStateActionOptions
   ): Promise<ExecutionResult> {

--- a/src/stateMachine/stateActions/FailStateAction.ts
+++ b/src/stateMachine/stateActions/FailStateAction.ts
@@ -1,6 +1,7 @@
 import type { JSONValue } from '../../typings/JSONValue';
 import type { FailState } from '../../typings/FailState';
 import type { ExecutionResult, FailStateActionOptions } from '../../typings/StateActions';
+import type { Context } from '../../typings/Context';
 import { BaseStateAction } from './BaseStateAction';
 import { FailStateError } from '../../error/FailStateError';
 
@@ -13,7 +14,7 @@ class FailStateAction extends BaseStateAction<FailState> {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     input: JSONValue,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    context: Record<string, unknown>,
+    context: Context,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     options?: FailStateActionOptions
   ): Promise<ExecutionResult> {

--- a/src/stateMachine/stateActions/MapStateAction.ts
+++ b/src/stateMachine/stateActions/MapStateAction.ts
@@ -1,6 +1,7 @@
 import type { MapState } from '../../typings/MapState';
 import type { JSONValue } from '../../typings/JSONValue';
 import type { ExecutionResult, MapStateActionOptions } from '../../typings/StateActions';
+import type { Context } from '../../typings/Context';
 import { BaseStateAction } from './BaseStateAction';
 import { StateMachine } from '../StateMachine';
 import { jsonPathQuery } from '../JsonPath';
@@ -27,7 +28,7 @@ class MapStateAction extends BaseStateAction<MapState> {
     stateMachine: StateMachine,
     item: JSONValue,
     input: JSONValue,
-    context: Record<string, unknown>,
+    context: Context,
     index: number,
     options: MapStateActionOptions | undefined
   ): Promise<JSONValue> {
@@ -56,7 +57,7 @@ class MapStateAction extends BaseStateAction<MapState> {
 
   override async execute(
     input: JSONValue,
-    context: Record<string, unknown>,
+    context: Context,
     options?: MapStateActionOptions
   ): Promise<ExecutionResult> {
     const state = this.stateDefinition;

--- a/src/stateMachine/stateActions/PassStateAction.ts
+++ b/src/stateMachine/stateActions/PassStateAction.ts
@@ -1,6 +1,7 @@
 import type { JSONValue } from '../../typings/JSONValue';
 import type { PassState } from '../../typings/PassState';
 import type { ExecutionResult, PassStateActionOptions } from '../../typings/StateActions';
+import type { Context } from '../../typings/Context';
 import { BaseStateAction } from './BaseStateAction';
 
 class PassStateAction extends BaseStateAction<PassState> {
@@ -11,7 +12,7 @@ class PassStateAction extends BaseStateAction<PassState> {
   override async execute(
     input: JSONValue,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    context: Record<string, unknown>,
+    context: Context,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     options?: PassStateActionOptions
   ): Promise<ExecutionResult> {

--- a/src/stateMachine/stateActions/SucceedStateAction.ts
+++ b/src/stateMachine/stateActions/SucceedStateAction.ts
@@ -1,6 +1,7 @@
 import type { JSONValue } from '../../typings/JSONValue';
 import type { ExecutionResult, SucceedStateActionOptions } from '../../typings/StateActions';
 import type { SucceedState } from '../../typings/SucceedState';
+import type { Context } from '../../typings/Context';
 import { BaseStateAction } from './BaseStateAction';
 
 class SucceedStateAction extends BaseStateAction<SucceedState> {
@@ -11,7 +12,7 @@ class SucceedStateAction extends BaseStateAction<SucceedState> {
   override async execute(
     input: JSONValue,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    context: Record<string, unknown>,
+    context: Context,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     options?: SucceedStateActionOptions
   ): Promise<ExecutionResult> {

--- a/src/stateMachine/stateActions/TaskStateAction.ts
+++ b/src/stateMachine/stateActions/TaskStateAction.ts
@@ -16,7 +16,6 @@ class TaskStateAction extends BaseStateAction<TaskState> {
     options?: TaskStateActionOptions
   ): Promise<ExecutionResult> {
     const state = this.stateDefinition;
-    const lambdaClient = new LambdaClient();
 
     // If local override for task resource is defined, use that
     if (options?.overrideFn) {
@@ -24,6 +23,7 @@ class TaskStateAction extends BaseStateAction<TaskState> {
       return this.buildExecutionResult(result);
     }
 
+    const lambdaClient = new LambdaClient();
     const result = await lambdaClient.invokeFunction(state.Resource, input);
     return this.buildExecutionResult(result);
   }

--- a/src/stateMachine/stateActions/TaskStateAction.ts
+++ b/src/stateMachine/stateActions/TaskStateAction.ts
@@ -1,6 +1,7 @@
 import type { TaskState } from '../../typings/TaskState';
 import type { JSONValue } from '../../typings/JSONValue';
 import type { ExecutionResult, TaskStateActionOptions } from '../../typings/StateActions';
+import type { Context } from '../../typings/Context';
 import { BaseStateAction } from './BaseStateAction';
 import { LambdaClient } from '../../aws/LambdaClient';
 
@@ -11,7 +12,7 @@ class TaskStateAction extends BaseStateAction<TaskState> {
 
   override async execute(
     input: JSONValue,
-    context: Record<string, unknown>,
+    context: Context,
     options?: TaskStateActionOptions
   ): Promise<ExecutionResult> {
     const state = this.stateDefinition;

--- a/src/stateMachine/stateActions/WaitStateAction.ts
+++ b/src/stateMachine/stateActions/WaitStateAction.ts
@@ -1,6 +1,7 @@
 import type { JSONValue } from '../../typings/JSONValue';
 import type { WaitState } from '../../typings/WaitState';
 import type { ExecutionResult, WaitStateActionOptions } from '../../typings/StateActions';
+import type { Context } from '../../typings/Context';
 import { BaseStateAction } from './BaseStateAction';
 import { jsonPathQuery } from '../JsonPath';
 import { sleep } from '../../util';
@@ -12,7 +13,7 @@ class WaitStateAction extends BaseStateAction<WaitState> {
 
   override async execute(
     input: JSONValue,
-    context: Record<string, unknown>,
+    context: Context,
     options?: WaitStateActionOptions
   ): Promise<ExecutionResult> {
     const state = this.stateDefinition;

--- a/src/typings/Context.ts
+++ b/src/typings/Context.ts
@@ -1,0 +1,1 @@
+export type Context = Record<string, unknown>;

--- a/src/typings/ErrorHandling.ts
+++ b/src/typings/ErrorHandling.ts
@@ -19,7 +19,7 @@ export interface CatchableState {
   Catch?: Catcher[];
 }
 
-export interface ErrorOutput {
+export type ErrorOutput = {
   Error: string;
   Cause?: string;
-}
+};

--- a/src/typings/InputOutputProcessing.ts
+++ b/src/typings/InputOutputProcessing.ts
@@ -1,4 +1,6 @@
-export type PayloadTemplate = object;
+import type { JSONObject } from './JSONValue';
+
+export type PayloadTemplate = JSONObject;
 
 export interface CanHaveInputPath {
   InputPath?: string | null;

--- a/src/typings/JSONValue.ts
+++ b/src/typings/JSONValue.ts
@@ -1,1 +1,9 @@
-export type JSONValue = null | boolean | number | string | object | JSONValue[];
+export type JSONPrimitiveValue = null | boolean | number | string;
+
+export type JSONArray = (JSONPrimitiveValue | JSONArray | JSONObject)[];
+
+export type JSONObject = {
+  [key: string]: JSONPrimitiveValue | JSONObject | JSONArray;
+};
+
+export type JSONValue = JSONPrimitiveValue | JSONObject | JSONArray;

--- a/src/typings/StateExecutor.ts
+++ b/src/typings/StateExecutor.ts
@@ -1,4 +1,5 @@
 import type { AllStates } from './AllStates';
+import type { Context } from './Context';
 import type { ErrorOutput } from './ErrorHandling';
 import type { JSONValue } from './JSONValue';
 import type { ExecutionResult } from './StateActions';
@@ -8,7 +9,7 @@ export type StateHandlers = {
   [T in AllStates as T['Type']]: (
     stateDefinition: T,
     input: JSONValue,
-    context: Record<string, unknown>,
+    context: Context,
     stateName: string,
     options: ExecuteOptions
   ) => Promise<ExecutionResult>;

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -20,7 +20,7 @@ export function sleep(ms: number, abortSignal?: AbortSignal) {
     const timeout = setTimeout(resolve, ms);
 
     abortSignal?.addEventListener('abort', () => {
-      timeout.unref();
+      clearTimeout(timeout);
     });
   });
 }

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,9 +1,11 @@
+import type { JSONObject } from '../typings/JSONValue';
+
 /**
  * Determines if a value is a plain object, i.e. one declared using the `{}` notation or constructed with `new Object()`.
  * @param value The value to test if it's a plain object or not.
  * @returns `true` if `value` is a plain object, `false` if not.
  */
-export function isPlainObj(value: unknown): boolean {
+export function isPlainObj(value: unknown): value is JSONObject {
   return !!value && Object.getPrototypeOf(value) === Object.prototype;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,6 @@
   "extends": "@tsconfig/node16-strictest/tsconfig.json",
   "compilerOptions": {
     "outDir": "build",
-    "target": "ES2015",
     "declaration": true,
     "noUncheckedIndexedAccess": false,
     "noUnusedParameters": false

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
     return { js: `.${format}.js` };
   },
   dts: true,
-  minify: true,
   clean: true,
   splitting: false,
 });


### PR DESCRIPTION
- Improve context object typing
- Don't minify build
- Transpile to ES2021
- Add example demonstrating checking for execution failure
- Other small improvements