### PR TITLE
Refactor 10

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -8,7 +8,7 @@ on:
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
-  run-tests:
+  publish-to-npm:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/__tests__/intrinsicFunctions/ArgumentHandling.test.ts
+++ b/__tests__/intrinsicFunctions/ArgumentHandling.test.ts
@@ -105,7 +105,7 @@ describe('Intrinsic function argument handling', () => {
 
         expect(validateArgumentsWrapper).toThrow(StatesRuntimeError);
         expect(validateArgumentsWrapper).toThrow(
-          /^Intrinsic function Generic.Function expected argument 1 to be of type "string", but received number$/
+          /^Intrinsic function Generic.Function expected argument 1 to be of type 'string', but received number$/
         );
       });
 
@@ -121,7 +121,7 @@ describe('Intrinsic function argument handling', () => {
 
         expect(validateArgumentsWrapper).toThrow(StatesRuntimeError);
         expect(validateArgumentsWrapper).toThrow(
-          /^Intrinsic function Generic.Function expected argument 1 to be of type "number", but received string$/
+          /^Intrinsic function Generic.Function expected argument 1 to be of type 'number', but received string$/
         );
       });
 
@@ -137,7 +137,7 @@ describe('Intrinsic function argument handling', () => {
 
         expect(validateArgumentsWrapper).toThrow(StatesRuntimeError);
         expect(validateArgumentsWrapper).toThrow(
-          /^Intrinsic function Generic.Function expected argument 1 to be of type "boolean", but received string$/
+          /^Intrinsic function Generic.Function expected argument 1 to be of type 'boolean', but received string$/
         );
       });
 
@@ -153,7 +153,7 @@ describe('Intrinsic function argument handling', () => {
 
         expect(validateArgumentsWrapper).toThrow(StatesRuntimeError);
         expect(validateArgumentsWrapper).toThrow(
-          /^Intrinsic function Generic.Function expected argument 1 to be of type "null", but received string$/
+          /^Intrinsic function Generic.Function expected argument 1 to be of type 'null', but received string$/
         );
       });
 
@@ -169,7 +169,7 @@ describe('Intrinsic function argument handling', () => {
 
         expect(validateArgumentsWrapper).toThrow(StatesRuntimeError);
         expect(validateArgumentsWrapper).toThrow(
-          /^Intrinsic function Generic.Function expected argument 1 to be of type "array", but received string$/
+          /^Intrinsic function Generic.Function expected argument 1 to be of type 'array', but received string$/
         );
       });
 
@@ -185,7 +185,7 @@ describe('Intrinsic function argument handling', () => {
 
         expect(validateArgumentsWrapper).toThrow(StatesRuntimeError);
         expect(validateArgumentsWrapper).toThrow(
-          /^Intrinsic function Generic.Function expected argument 1 to be of type "object", but received string$/
+          /^Intrinsic function Generic.Function expected argument 1 to be of type 'object', but received string$/
         );
       });
 
@@ -221,7 +221,7 @@ describe('Intrinsic function argument handling', () => {
 
         expect(validateArgumentsWrapper).toThrow(StatesRuntimeError);
         expect(validateArgumentsWrapper).toThrow(
-          /^Intrinsic function Generic.Function expected argument 1 to satisfy the following constraints: "ZERO"$/
+          /^Intrinsic function Generic.Function expected argument 1 to satisfy the following constraints: 'ZERO'$/
         );
       });
 
@@ -242,7 +242,7 @@ describe('Intrinsic function argument handling', () => {
 
         expect(validateArgumentsWrapper).toThrow(StatesRuntimeError);
         expect(validateArgumentsWrapper).toThrow(
-          /^Intrinsic function Generic.Function expected argument 1 to satisfy the following constraints: "POSITIVE_INTEGER"$/
+          /^Intrinsic function Generic.Function expected argument 1 to satisfy the following constraints: 'POSITIVE_INTEGER'$/
         );
       });
 
@@ -263,7 +263,7 @@ describe('Intrinsic function argument handling', () => {
 
         expect(validateArgumentsWrapper).toThrow(StatesRuntimeError);
         expect(validateArgumentsWrapper).toThrow(
-          /^Intrinsic function Generic.Function expected argument 1 to satisfy the following constraints: "NEGATIVE_INTEGER"$/
+          /^Intrinsic function Generic.Function expected argument 1 to satisfy the following constraints: 'NEGATIVE_INTEGER'$/
         );
       });
 
@@ -284,7 +284,7 @@ describe('Intrinsic function argument handling', () => {
 
         expect(validateArgumentsWrapper).toThrow(StatesRuntimeError);
         expect(validateArgumentsWrapper).toThrow(
-          /^Intrinsic function Generic.Function expected argument 1 to satisfy the following constraints: "INTEGER"$/
+          /^Intrinsic function Generic.Function expected argument 1 to satisfy the following constraints: 'INTEGER'$/
         );
       });
     });

--- a/src/aws/LambdaClient.ts
+++ b/src/aws/LambdaClient.ts
@@ -23,14 +23,14 @@ export class LambdaClient {
     if (config) {
       if (!config.region) {
         throw new StatesRuntimeError(
-          '`awsConfig` option was specified for state machine, but `region` property is not set'
+          "'awsConfig' option was specified for state machine, but 'region' property is not set"
         );
       }
 
       // Check if multiple types of credentials were passed. Passing more than one type is an error.
       if (config.credentials) {
         const credentialsTypes = Object.keys(config.credentials);
-        const credentialsNames = credentialsTypes.map((name) => `\`${name}\``).join(', ');
+        const credentialsNames = credentialsTypes.map((name) => `'${name}'`).join(', ');
         if (credentialsTypes.length > 1) {
           throw new StatesRuntimeError(
             `More than one type of AWS credentials were specified: ${credentialsNames}. Only one type may be specified`
@@ -72,7 +72,7 @@ export class LambdaClient {
       const errorResult = resultValue as LambdaErrorResult;
       // Even though this is not a Fail State, we can take advantage of the `FailStateError`
       // to throw an error with a custom name and message.
-      throw new FailStateError(errorResult.errorType, `Execution of Lambda function "${funcNameOrArn}" failed`);
+      throw new FailStateError(errorResult.errorType, `Execution of Lambda function '${funcNameOrArn}' failed`);
     }
 
     return resultValue;

--- a/src/stateMachine/InputOutputProcessing.ts
+++ b/src/stateMachine/InputOutputProcessing.ts
@@ -41,7 +41,7 @@ function processPayloadTemplate(payloadTemplate: PayloadTemplate, json: JSONValu
 
     // Recursively process child object
     if (isPlainObj(value)) {
-      resolvedValue = processPayloadTemplate(value, json);
+      resolvedValue = processPayloadTemplate(value, json, context);
     }
 
     // Only resolve value if key ends with `.$` and value is a string

--- a/src/stateMachine/StateMachine.ts
+++ b/src/stateMachine/StateMachine.ts
@@ -35,14 +35,16 @@ export class StateMachine {
    * These options also apply to state machines defined in the `Iterator` field of `Map` states and in the `Branches` field of `Parallel` states.
    */
   constructor(definition: StateMachineDefinition, stateMachineOptions?: StateMachineOptions) {
-    const { isValid, errorsText } = aslValidator(definition, {
-      checkArn: true,
-      checkPaths: true,
-      ...stateMachineOptions?.validationOptions,
-    });
+    if (!stateMachineOptions?.validationOptions?._noValidate) {
+      const { isValid, errorsText } = aslValidator(definition, {
+        checkArn: true,
+        checkPaths: true,
+        ...stateMachineOptions?.validationOptions,
+      });
 
-    if (!isValid) {
-      throw new Error(`State machine definition is invalid, see error(s) below:\n ${errorsText('\n')}`);
+      if (!isValid) {
+        throw new Error(`State machine definition is invalid, see error(s) below:\n ${errorsText('\n')}`);
+      }
     }
 
     this.definition = definition;

--- a/src/stateMachine/intrinsicFunctions/ArgumentHandling.ts
+++ b/src/stateMachine/intrinsicFunctions/ArgumentHandling.ts
@@ -35,7 +35,7 @@ function validateArgumentType(allowedTypes: ArgumentType[], argPosition: number,
     if (matchesAllowedType) break;
   }
 
-  const expectedType = allowedTypes.map((type) => `"${type}"`).join(' | ');
+  const expectedType = allowedTypes.map((type) => `'${type}'`).join(' | ');
   if (!matchesAllowedType) {
     throw new StatesRuntimeError(
       `Intrinsic function ${funcName} expected argument ${argPosition} to be of type ${expectedType}, but received ${typeof funcArg}`
@@ -70,7 +70,7 @@ function validateArgumentConstraints(
       if (matchesAllConstraints) break;
     }
 
-    const expectedConstraints = argConstraints.map((constraint) => `"${constraint}"`).join(' | ');
+    const expectedConstraints = argConstraints.map((constraint) => `'${constraint}'`).join(' | ');
     if (!matchesAllConstraints) {
       throw new StatesRuntimeError(
         `Intrinsic function ${funcName} expected argument ${argPosition} to satisfy the following constraints: ${expectedConstraints}`

--- a/src/stateMachine/stateActions/MapStateAction.ts
+++ b/src/stateMachine/stateActions/MapStateAction.ts
@@ -71,7 +71,10 @@ class MapStateAction extends BaseStateAction<MapState> {
       throw new StatesRuntimeError('Input of Map state must be an array or ItemsPath property must point to an array');
     }
 
-    const iteratorStateMachine = new StateMachine(state.Iterator, options?.stateMachineOptions);
+    const iteratorStateMachine = new StateMachine(state.Iterator, {
+      ...options?.stateMachineOptions,
+      validationOptions: { _noValidate: true },
+    });
     const limit = pLimit(state.MaxConcurrency || DEFAULT_MAX_CONCURRENCY);
     const processedItemsPromise = items.map((item, i) =>
       limit(() => this.processItem(iteratorStateMachine, item, input, context, i, options))

--- a/src/stateMachine/stateActions/ParallelStateAction.ts
+++ b/src/stateMachine/stateActions/ParallelStateAction.ts
@@ -27,7 +27,10 @@ class ParallelStateAction extends BaseStateAction<ParallelState> {
     context: Context,
     options: ParallelStateActionOptions | undefined
   ): Promise<JSONValue> {
-    const stateMachine = new StateMachine(branch, options?.stateMachineOptions);
+    const stateMachine = new StateMachine(branch, {
+      ...options?.stateMachineOptions,
+      validationOptions: { _noValidate: true },
+    });
     const execution = stateMachine.run(input, options?.runOptions);
 
     this.executionAbortFuncs.push(execution.abort);

--- a/src/typings/StateMachineImplementation.ts
+++ b/src/typings/StateMachineImplementation.ts
@@ -1,6 +1,6 @@
 import type { JSONValue } from './JSONValue';
 import type { FromCognitoIdentityPoolParameters } from '@aws-sdk/credential-provider-cognito-identity/dist-types/fromCognitoIdentityPool';
-import type { Credentials as AWSCredentials } from '@aws-sdk/types/dist-types/credentials';
+import type { AwsCredentialIdentity as AWSCredentials } from '@aws-sdk/types/dist-types/identity/AwsCredentialIdentity';
 
 export type TaskStateResourceLocalHandler = {
   [taskStateName: string]: (input: JSONValue) => Promise<JSONValue>;

--- a/src/typings/StateMachineImplementation.ts
+++ b/src/typings/StateMachineImplementation.ts
@@ -18,6 +18,10 @@ interface Overrides {
 export interface ValidationOptions {
   readonly checkPaths?: boolean;
   readonly checkArn?: boolean;
+  /**
+   * @internal DO NOT USE. This property is meant for internal use only.
+   */
+  readonly _noValidate?: boolean;
 }
 
 export interface AWSConfig {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "declaration": true,
     "noUncheckedIndexedAccess": false,
     "noUnusedParameters": false,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "stripInternal": true
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules"]

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -44,7 +44,6 @@ export default defineConfig([
     ...getPackageConfig('node'),
     format: ['cjs', 'esm'],
     dts: true,
-    clean: true,
   },
   {
     ...getPackageConfig('browser'),


### PR DESCRIPTION
- Don't validate state machine definition when running `Map` or `Parallel` state, as it would've already been validated the first time a `StateMachine` is instantiated.
- Fixes bug in which nested child object in `Parameters` could not resolve context JSONPath.
- Other minor/internal improvements.