### PR TITLE
Refactor 11

### DIFF
--- a/__tests__/StateMachine.test.ts
+++ b/__tests__/StateMachine.test.ts
@@ -104,7 +104,7 @@ describe('State Machine', () => {
 
       execution.abort();
 
-      await expect(() => execution.result).rejects.toThrow(ExecutionAbortedError);
+      await expect(execution.result).rejects.toThrow(ExecutionAbortedError);
     });
 
     test('should return `null` if `noThrowOnAbort` option is passed', async () => {
@@ -135,7 +135,7 @@ describe('State Machine', () => {
       const stateMachine = new StateMachine(machineDefinition);
       const execution = stateMachine.run(input);
 
-      await expect(() => execution.result).rejects.toThrow(StatesTimeoutError);
+      await expect(execution.result).rejects.toThrow(StatesTimeoutError);
     });
 
     test('should throw an `ExecutionError` if execution fails', async () => {

--- a/__tests__/cli/CLI.test.ts
+++ b/__tests__/cli/CLI.test.ts
@@ -32,7 +32,7 @@ describe('CLI', () => {
         },
       });
 
-      await expect(() => program.parseAsync([], { from: 'user' })).rejects.toThrow();
+      await expect(program.parseAsync([], { from: 'user' })).rejects.toThrow();
       expect(helpStr).toBe(
         'Usage: local-sfn [options] [inputs...]\n\nExecute an Amazon States Language state machine with the given inputs.\nThe result of each execution will be output in a new line and in the same order\nas its corresponding input.\n\nArguments:\n  inputs                         Input data for the state machine, can be any\n                                 valid JSON value. Each input represents a\n                                 state machine execution. If reading from the\n                                 standard input, each line will be considered\n                                 as an input.\n\nOptions:\n  -V, --version                  Print the version number and exit.\n  -d, --definition <definition>  A JSON definition of a state machine.\n  -f, --definition-file <path>   Path to a file containing a JSON state machine\n                                 definition.\n  -t, --override-task <mapping>  Override a Task state to run an executable\n                                 file or script, instead of calling the service\n                                 specified in the \'Resource\' field of the state\n                                 definition. The mapping value has to be\n                                 provided in the format\n                                 [TaskStateToOverride]:[path/to/override/script].\n                                 The override script will be passed the input\n                                 of the Task state as first argument, which can\n                                 then be used to compute the task result. The\n                                 script must print the task result as a JSON\n                                 value to the standard output.\n  -w, --override-wait <mapping>  Override a Wait state to pause for the\n                                 specified amount of milliseconds, instead of\n                                 pausing for the duration specified in the\n                                 state definition. The mapping value has to be\n                                 provided in the format\n                                 [WaitStateToOverride]:[number].\n  --no-jsonpath-validation       Disable validation of JSONPath strings in the\n                                 state machine definition.\n  --no-arn-validation            Disable validation of ARNs in the state\n                                 machine definition.\n  -h, --help                     Print help for command and exit.\n\nExit codes:\n  0\tAll executions ran successfully.\n  1\tAn error occurred before the state machine could be executed.\n  2\tAt least one execution had an error.\n\nExample calls:\n  $ local-sfn -f state-machine.json \'{ "num1": 2, "num2": 2 }\'\n  $ local-sfn -f state-machine.json -t SendRequest:./override.sh -w WaitResponse:2000 \'{ "num1": 2, "num2": 2 }\'\n  $ cat inputs.txt | local-sfn -f state-machine.json\n'
       );
@@ -52,7 +52,7 @@ describe('CLI', () => {
       });
 
       // program.parseAsync(['{}'], { from: 'user' });
-      await expect(() => program.parseAsync(['{}'], { from: 'user' })).rejects.toThrow();
+      await expect(program.parseAsync(['{}'], { from: 'user' })).rejects.toThrow();
       expect(errStr).toBe(
         "error: missing either option '-d, --definition <definition>' or option '-f, --definition-file <path>'\n"
       );
@@ -81,7 +81,7 @@ describe('CLI', () => {
         },
       });
 
-      await expect(() => program.parseAsync(['-d', definition, '{}'], { from: 'user' })).rejects.toThrow();
+      await expect(program.parseAsync(['-d', definition, '{}'], { from: 'user' })).rejects.toThrow();
       expect(errStr).toBe(
         "error: parsing of state machine definition passed in option '-d, --definition <definition>' failed: Unexpected token S in JSON at position 12\n"
       );
@@ -105,7 +105,7 @@ describe('CLI', () => {
         },
       });
 
-      await expect(() => program.parseAsync(['-f', filePath, '{}'], { from: 'user' })).rejects.toThrow();
+      await expect(program.parseAsync(['-f', filePath, '{}'], { from: 'user' })).rejects.toThrow();
       expect(errStr).toBe("error: ENOENT: no such file or directory, open '/path/to/nonexistent/file'\n");
     });
 
@@ -138,7 +138,7 @@ describe('CLI', () => {
         },
       });
 
-      await expect(() => program.parseAsync(['-f', filePath, '{}'], { from: 'user' })).rejects.toThrow();
+      await expect(program.parseAsync(['-f', filePath, '{}'], { from: 'user' })).rejects.toThrow();
       expect(errStr).toBe(
         "error: parsing of state machine definition in file './state-machine.asl.json' failed: Unexpected token S in JSON at position 12\n"
       );
@@ -167,7 +167,7 @@ describe('CLI', () => {
         },
       });
 
-      await expect(() => program.parseAsync(['-d', definition, input], { from: 'user' })).rejects.toThrow();
+      await expect(program.parseAsync(['-d', definition, input], { from: 'user' })).rejects.toThrow();
       expect(errStr).toBe(
         "error: parsing of input value '{ key: 123 }' failed: Unexpected token k in JSON at position 2\n"
       );
@@ -196,7 +196,7 @@ describe('CLI', () => {
         },
       });
 
-      await expect(() => program.parseAsync(['-d', definition, '{}'], { from: 'user' })).rejects.toThrow();
+      await expect(program.parseAsync(['-d', definition, '{}'], { from: 'user' })).rejects.toThrow();
       expect(errStr).toBe(
         'error: State machine definition is invalid, see error(s) below:\n SCHEMA_VALIDATION_FAILED: /States/AddNumbers/OutputPath is invalid. must match format "asl_path"\n'
       );
@@ -224,7 +224,7 @@ describe('CLI', () => {
         },
       });
 
-      await expect(() => program.parseAsync(['-d', definition, '{}'], { from: 'user' })).rejects.toThrow();
+      await expect(program.parseAsync(['-d', definition, '{}'], { from: 'user' })).rejects.toThrow();
       expect(errStr).toBe(
         'error: State machine definition is invalid, see error(s) below:\n SCHEMA_VALIDATION_FAILED: /States/AddNumbers/Resource is invalid. must match exactly one schema in oneOf\n'
       );

--- a/__tests__/util/index.test.ts
+++ b/__tests__/util/index.test.ts
@@ -1,0 +1,51 @@
+import { isPlainObj, sleep } from '../../src/util';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('Utils', () => {
+  describe('isPlainObj', () => {
+    test('should return `true` if object is plain object', () => {
+      const object = { a: 1, b: 'str', c: false, d: [1, 'str', false], e: {} };
+      const result = isPlainObj(object);
+
+      expect(result).toBe(true);
+    });
+
+    test('should return `false` if object is not plain object', () => {
+      const array = [1, 2, 3];
+      const number = 123;
+      const classObject = new (class MyClass {})();
+
+      const result = isPlainObj(array);
+      const result2 = isPlainObj(number);
+      const result3 = isPlainObj(classObject);
+
+      expect(result).toBe(false);
+      expect(result2).toBe(false);
+      expect(result3).toBe(false);
+    });
+  });
+
+  describe('sleep', () => {
+    test('should resolve promise after the specified number of milliseconds have elapsed', async () => {
+      jest.useFakeTimers();
+
+      const sleepPromise = sleep(1000);
+
+      jest.runAllTimers();
+
+      await expect(sleepPromise).resolves.not.toThrow();
+    });
+
+    test('should resolve promise when sleep is aborted', async () => {
+      const abortController = new AbortController();
+
+      const sleepPromise = sleep(1000, abortController.signal);
+      abortController.abort();
+
+      await expect(sleepPromise).resolves.not.toThrow();
+    });
+  });
+});

--- a/docs/feature-support.md
+++ b/docs/feature-support.md
@@ -17,6 +17,8 @@ The following features all come from the [Amazon States Language specification](
 
 ### Fully supported
 
+- Top-level fields
+  - [x] `TimeoutSeconds`
 - Input processing
   - [x] `InputPath`
   - [x] `Parameters`

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -16,11 +16,12 @@ export function isPlainObj(value: unknown): value is JSONObject {
  * @param abortSignal An abort signal that can cancel the sleep if the signal is aborted.
  */
 export function sleep(ms: number, abortSignal?: AbortSignal) {
-  return new Promise((resolve) => {
+  return new Promise<void>((resolve) => {
     const timeout = setTimeout(resolve, ms);
 
     abortSignal?.addEventListener('abort', () => {
       clearTimeout(timeout);
+      resolve();
     });
   });
 }

--- a/src/util/random.ts
+++ b/src/util/random.ts
@@ -49,9 +49,9 @@ export function sfc32(a: number, b: number, c: number, d: number) {
  * Generates a random integer between two bounds.
  * @param min Lower bound of the range.
  * @param max High bound of the range.
- * @param rngGenerator A generator function that produces random values between 0 and 1. If not specified, uses `Math.random` as default.
+ * @param rng A generator function that produces random values between 0 and 1. If not specified, uses `Math.random` as default.
  * @returns A random integer between `min` and `max` (both inclusive)
  */
-export function getRandomNumber(min: number, max: number, rngGenerator = Math.random) {
-  return Math.floor(rngGenerator() * (max - min + 1)) + min;
+export function getRandomNumber(min: number, max: number, rng = Math.random) {
+  return Math.floor(rng() * (max - min + 1)) + min;
 }


### PR DESCRIPTION
- Resolve `sleep` promise immediately on abort
- Add tests for `isPlainObj` and `sleep` util functions
- Document support for top-level `TimeoutSeconds`
- Other minor/internal improvements