### PR TITLE
Feature/lambda error cause

### DIFF
--- a/docs/execution-event-logs.md
+++ b/docs/execution-event-logs.md
@@ -78,7 +78,9 @@ The `ExecutionFailed` event is produced when the execution encounters an error a
 #### Additional fields
 
 - `Error`: Name of the error that caused the failure.
-- `Cause`: A human-readable description explaining why the execution failed.
+- `Cause`: This field can either be a string or an object:
+  - `string`: Contains a description explaining why the execution failed.
+  - `object`: Contains details that provide information as to why the execution failed.
 
 #### Example
 
@@ -202,7 +204,9 @@ The `MapIterationFailed` event is produced when an iteration in a `Map` encounte
 - `parentState`: An object of type [`StateData`](#statedata) containing data associated with the `Map` state to which this iteration belongs to.
 - `index`: The index of this iteration.
 - `Error`: Name of the error that caused the failure.
-- `Cause`: A human-readable description explaining why the iteration failed.
+- `Cause`: This field can either be a string or an object:
+  - `string`: Contains a description explaining why the iteration failed.
+  - `object`: Contains details that provide information as to why the iteration failed.
 
 #### Example
 
@@ -286,7 +290,9 @@ The `ParallelBranchFailed` event is produced when a branch in a `Parallel` state
 
 - `parentState`: An object of type [`StateData`](#statedata) containing data associated with the `Parallel` state to which this branch belongs to.
 - `Error`: Name of the error that caused the failure.
-- `Cause`: A human-readable description explaining why the branch failed.
+- `Cause`: This field can either be a string or an object:
+  - `string`: Contains a description explaining why the branch failed.
+  - `object`: Contains details that provide information as to why the branch failed.
 
 #### Example
 

--- a/src/error/ErrorWithCause.ts
+++ b/src/error/ErrorWithCause.ts
@@ -1,0 +1,12 @@
+export class ErrorWithCause extends Error {
+  #errorCause: unknown;
+
+  constructor(message: string, options?: { cause: unknown }) {
+    super(message);
+    this.#errorCause = options?.cause;
+  }
+
+  public get cause(): unknown {
+    return this.#errorCause;
+  }
+}

--- a/src/error/ExecutionError.ts
+++ b/src/error/ExecutionError.ts
@@ -1,19 +1,13 @@
 import type { RuntimeError } from './RuntimeError';
+import { ErrorWithCause } from './ErrorWithCause';
 
 /**
  * Represents the failure of a state machine execution.
  */
-export class ExecutionError extends Error {
-  #wrappedError: RuntimeError;
-
+export class ExecutionError extends ErrorWithCause {
   constructor(caughtError: RuntimeError) {
-    super(`Execution has failed with the following error: ${caughtError.message}`);
+    super(`Execution has failed with the following error: ${caughtError.message}`, { cause: caughtError });
 
     this.name = 'ExecutionError';
-    this.#wrappedError = caughtError;
-  }
-
-  public get getWrappedError(): RuntimeError {
-    return this.#wrappedError;
   }
 }

--- a/src/error/LambdaInvocationError.ts
+++ b/src/error/LambdaInvocationError.ts
@@ -1,0 +1,10 @@
+import type { LambdaErrorResult } from '../typings/LambdaExecution';
+import { RuntimeError } from './RuntimeError';
+
+export class LambdaInvocationError extends RuntimeError {
+  constructor(name: string, message: string, cause: LambdaErrorResult) {
+    super(message, cause);
+
+    this.name = name;
+  }
+}

--- a/src/error/RuntimeError.ts
+++ b/src/error/RuntimeError.ts
@@ -1,7 +1,9 @@
+import { ErrorWithCause } from './ErrorWithCause';
+
 /**
  * Base class for all internal errors that can be thrown during the state machine execution.
  */
-export abstract class RuntimeError extends Error {
+export abstract class RuntimeError extends ErrorWithCause {
   /**
    * Whether this runtime error can be matched in a `Retry` field
    */
@@ -12,8 +14,8 @@ export abstract class RuntimeError extends Error {
    */
   protected catchable: boolean;
 
-  constructor(message: string) {
-    super(message);
+  constructor(message: string, cause?: unknown) {
+    super(message, { cause });
 
     this.name = 'RuntimeError';
     this.retryable = true;

--- a/src/stateMachine/EventLogger.ts
+++ b/src/stateMachine/EventLogger.ts
@@ -106,7 +106,12 @@ export class EventLogger {
   }
 
   dispatchExecutionFailedEvent(error: RuntimeError) {
-    this.dispatch({ type: 'ExecutionFailed', timestamp: Date.now(), Error: error.name, Cause: error.message });
+    this.dispatch({
+      type: 'ExecutionFailed',
+      timestamp: Date.now(),
+      Error: error.name,
+      Cause: error.cause ?? error.message,
+    });
     this.close();
   }
 

--- a/src/stateMachine/stateActions/MapStateAction.ts
+++ b/src/stateMachine/stateActions/MapStateAction.ts
@@ -104,7 +104,7 @@ class MapStateAction extends BaseStateAction<MapState> {
       this.executionAbortFuncs.forEach((abort) => abort());
 
       if (error instanceof ExecutionError) {
-        throw error.getWrappedError;
+        throw error.cause;
       }
 
       throw error;

--- a/src/stateMachine/stateActions/ParallelStateAction.ts
+++ b/src/stateMachine/stateActions/ParallelStateAction.ts
@@ -77,7 +77,7 @@ class ParallelStateAction extends BaseStateAction<ParallelState> {
       this.executionAbortFuncs.forEach((abort) => abort());
 
       if (error instanceof ExecutionError) {
-        throw error.getWrappedError;
+        throw error.cause;
       }
 
       throw error;

--- a/src/typings/EventLogs.ts
+++ b/src/typings/EventLogs.ts
@@ -1,4 +1,3 @@
-import type { ErrorOutput } from './ErrorHandling';
 import type { JSONValue } from './JSONValue';
 import type { StateType } from './StateType';
 
@@ -33,6 +32,11 @@ interface StateData {
   output?: JSONValue;
 }
 
+interface ErrorInfo {
+  Error: string;
+  Cause: unknown;
+}
+
 interface BaseEvent {
   type: AllEventTypes;
   timestamp: number;
@@ -48,7 +52,7 @@ export interface ExecutionSucceededEvent extends BaseEvent {
   output: JSONValue;
 }
 
-export interface ExecutionFailedEvent extends BaseEvent, ErrorOutput {
+export interface ExecutionFailedEvent extends BaseEvent, ErrorInfo {
   type: ExecutionFailedEventType;
 }
 
@@ -66,7 +70,7 @@ interface MapIterationEvent extends BaseMapIterationEvent {
   type: MapIterationEventType;
 }
 
-interface MapIterationFailedEvent extends BaseMapIterationEvent, ErrorOutput {
+interface MapIterationFailedEvent extends BaseMapIterationEvent, ErrorInfo {
   type: MapIterationFailedEventType;
 }
 
@@ -79,7 +83,7 @@ interface ParallelBranchEvent extends BaseParallelBranchEvent {
   type: ParallelBranchEventType;
 }
 
-interface ParallelBranchFailedEvent extends BaseParallelBranchEvent, ErrorOutput {
+interface ParallelBranchFailedEvent extends BaseParallelBranchEvent, ErrorInfo {
   type: ParallelBranchFailedEventType;
 }
 

--- a/src/typings/LambdaExecution.ts
+++ b/src/typings/LambdaExecution.ts
@@ -1,0 +1,5 @@
+export interface LambdaErrorResult {
+  errorType: string;
+  errorMessage: string;
+  trace: string[];
+}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,5 +1,9 @@
 import type { JSONObject } from '../typings/JSONValue';
 
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+export const isBrowserEnvironment = typeof window !== 'undefined' && typeof window.document !== 'undefined';
+
 /**
  * Determines if a value is a plain object, i.e. one declared using the `{}` notation or constructed with `new Object()`.
  * @param value The value to test if it's a plain object or not.


### PR DESCRIPTION
- Sets `Cause` field in `ExecutionFailed` event to the error result returned by the Lambda function when invocation fails, to be more consistent with the [`GetExecutionHistory`](https://docs.aws.amazon.com/step-functions/latest/apireference/API_GetExecutionHistory.html) action of the Step Functions API.
- Provides better errors when using `aws-local-stepfunctions` in a browser environment and an AWS config is not passed.
- Polyfills the `cause` property of the `Error` object.