### PR TITLE
Fix/jsonpath invalid evaluation

### DIFF
--- a/__tests__/InputOutputProcessing.test.ts
+++ b/__tests__/InputOutputProcessing.test.ts
@@ -30,8 +30,9 @@ describe('Input processing', () => {
           lastUpdated: '2020-05-27T08:00:00Z',
         },
       };
+      const context = {};
 
-      const result = processInputPath(undefined, input);
+      const result = processInputPath(undefined, input, context);
 
       expect(result).toEqual(input);
     });
@@ -54,8 +55,9 @@ describe('Input processing', () => {
           lastUpdated: '2020-05-27T08:00:00Z',
         },
       };
+      const context = {};
 
-      const result = processInputPath('$.movies', input);
+      const result = processInputPath('$.movies', input, context);
 
       expect(result).toEqual([
         {
@@ -89,8 +91,9 @@ describe('Input processing', () => {
           lastUpdated: '2020-05-27T08:00:00Z',
         },
       };
+      const context = {};
 
-      const result = processInputPath(null, input);
+      const result = processInputPath(null, input, context);
 
       expect(result).toEqual({});
     });
@@ -108,8 +111,9 @@ describe('Input processing', () => {
         },
       };
       const input = {};
+      const context = {};
 
-      const result = processPayloadTemplate(parameters, input);
+      const result = processPayloadTemplate(parameters, input, context);
 
       expect(result).toEqual({
         field1: 50,
@@ -149,8 +153,9 @@ describe('Input processing', () => {
           lastUpdated: '2020-05-27T08:00:00Z',
         },
       };
+      const context = {};
 
-      const result = processPayloadTemplate(parameters, input);
+      const result = processPayloadTemplate(parameters, input, context);
 
       expect(result).toEqual({
         field1: 50,
@@ -192,8 +197,9 @@ describe('Input processing', () => {
           lastUpdated: '2020-05-27T08:00:00Z',
         },
       };
+      const context = {};
 
-      const result = processPayloadTemplate(parameters, input);
+      const result = processPayloadTemplate(parameters, input, context);
 
       expect(result).toEqual({
         field1: 50,
@@ -247,8 +253,9 @@ describe('Input processing', () => {
           lastUpdated: '2020-05-27T08:00:00Z',
         },
       };
+      const context = {};
 
-      const result = processPayloadTemplate(parameters, input);
+      const result = processPayloadTemplate(parameters, input, context);
 
       expect(result).toEqual({
         field1: 50,
@@ -279,8 +286,9 @@ describe('Output processing', () => {
         },
       };
       const input = {};
+      const context = {};
 
-      const result = processPayloadTemplate(resultSelector, input);
+      const result = processPayloadTemplate(resultSelector, input, context);
 
       expect(result).toEqual({
         field1: 50,
@@ -320,8 +328,9 @@ describe('Output processing', () => {
           lastUpdated: '2020-05-27T08:00:00Z',
         },
       };
+      const context = {};
 
-      const result = processPayloadTemplate(resultSelector, input);
+      const result = processPayloadTemplate(resultSelector, input, context);
 
       expect(result).toEqual({
         field1: 50,
@@ -363,8 +372,9 @@ describe('Output processing', () => {
           lastUpdated: '2020-05-27T08:00:00Z',
         },
       };
+      const context = {};
 
-      const result = processPayloadTemplate(resultSelector, input);
+      const result = processPayloadTemplate(resultSelector, input, context);
 
       expect(result).toEqual({
         field1: 50,
@@ -418,8 +428,9 @@ describe('Output processing', () => {
           lastUpdated: '2020-05-27T08:00:00Z',
         },
       };
+      const context = {};
 
-      const result = processPayloadTemplate(resultSelector, input);
+      const result = processPayloadTemplate(resultSelector, input, context);
 
       expect(result).toEqual({
         field1: 50,
@@ -621,8 +632,9 @@ describe('Output processing', () => {
           lastUpdated: '2020-05-27T08:00:00Z',
         },
       };
+      const context = {};
 
-      const result = processOutputPath(undefined, input);
+      const result = processOutputPath(undefined, input, context);
 
       expect(result).toEqual(input);
     });
@@ -645,8 +657,9 @@ describe('Output processing', () => {
           lastUpdated: '2020-05-27T08:00:00Z',
         },
       };
+      const context = {};
 
-      const result = processOutputPath('$.movies', input);
+      const result = processOutputPath('$.movies', input, context);
 
       expect(result).toEqual([
         {
@@ -680,8 +693,9 @@ describe('Output processing', () => {
           lastUpdated: '2020-05-27T08:00:00Z',
         },
       };
+      const context = {};
 
-      const result = processOutputPath(null, input);
+      const result = processOutputPath(null, input, context);
 
       expect(result).toEqual({});
     });

--- a/__tests__/jsonPath/JsonPath.test.ts
+++ b/__tests__/jsonPath/JsonPath.test.ts
@@ -1,0 +1,62 @@
+import { jsonPathQuery } from '../../src/stateMachine/jsonPath/JsonPath';
+import { IntegerConstraint } from '../../src/stateMachine/jsonPath/constraints/IntegerConstraint';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('jsonPathQuery', () => {
+  const testObject = {
+    a: 1,
+    b: 2,
+    c: [3, 4, 5],
+    d: { e: 6 },
+  };
+  const context = {
+    executionId: 'id-12345',
+  };
+
+  test('should query `json` parameter if path expression starts with `$`', () => {
+    const pathExpression = '$.a';
+
+    const result = jsonPathQuery(pathExpression, testObject, context);
+    expect(result).toBe(1);
+  });
+
+  test('should query Context Object if path expression starts with `$$`', () => {
+    const pathExpression = '$$.executionId';
+
+    const result = jsonPathQuery(pathExpression, testObject, context);
+    expect(result).toBe('id-12345');
+  });
+
+  describe('constraints', () => {
+    test('should return value if path is valid', () => {
+      const pathExpression = '$.d.e';
+
+      const result = jsonPathQuery(pathExpression, testObject, context);
+      expect(result).toBe(6);
+    });
+
+    test('should check default `DefinedValueConstraint` constraint', () => {
+      const pathExpression = '$.nonexistent';
+
+      const testFn = () => jsonPathQuery(pathExpression, testObject, context);
+      expect(testFn).toThrow("Path expression '$.nonexistent' does not point to a value");
+    });
+
+    test('should not check default `DefinedValueConstraint` constraint if `ignoreDefinedValueConstraint` option is true', () => {
+      const pathExpression = '$.nonexistent';
+
+      const testFn = () => jsonPathQuery(pathExpression, testObject, context, { ignoreDefinedValueConstraint: true });
+      expect(testFn).not.toThrow();
+    });
+
+    test('should check for any constraints provided by the caller', () => {
+      const pathExpression = '$.c';
+
+      const testFn = () => jsonPathQuery(pathExpression, testObject, context, { constraints: [IntegerConstraint] });
+      expect(testFn).toThrow("Path expression '$.c' evaluated to [3,4,5], but expected an integer");
+    });
+  });
+});

--- a/__tests__/jsonPath/constraints/ArrayConstraint.test.ts
+++ b/__tests__/jsonPath/constraints/ArrayConstraint.test.ts
@@ -1,0 +1,27 @@
+import { StatesRuntimeError } from '../../../src/error/predefined/StatesRuntimeError';
+import { ArrayConstraint } from '../../../src/stateMachine/jsonPath/constraints/ArrayConstraint';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('ArrayConstraint', () => {
+  test('should not throw if passed value is an array', () => {
+    const value = ['item', 1, { a: 1, b: 2 }, [], true];
+
+    const constraint = new ArrayConstraint('');
+
+    const testFunc = () => constraint.test(value);
+    expect(testFunc).not.toThrow();
+  });
+
+  test('should throw if passed value is not an array', () => {
+    const value = 55;
+
+    const constraint = new ArrayConstraint('');
+
+    const testFunc = () => constraint.test(value);
+    expect(testFunc).toThrow("Path expression '' evaluated to 55, but expected an array");
+    expect(testFunc).toThrow(StatesRuntimeError);
+  });
+});

--- a/__tests__/jsonPath/constraints/BooleanConstraint.test.ts
+++ b/__tests__/jsonPath/constraints/BooleanConstraint.test.ts
@@ -1,0 +1,27 @@
+import { StatesRuntimeError } from '../../../src/error/predefined/StatesRuntimeError';
+import { BooleanConstraint } from '../../../src/stateMachine/jsonPath/constraints/BooleanConstraint';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('BooleanConstraint', () => {
+  test('should not throw if passed value is a boolean', () => {
+    const value = true;
+
+    const constraint = new BooleanConstraint('');
+
+    const testFunc = () => constraint.test(value);
+    expect(testFunc).not.toThrow();
+  });
+
+  test('should throw if passed value is not a boolean', () => {
+    const value = 'hello';
+
+    const constraint = new BooleanConstraint('');
+
+    const testFunc = () => constraint.test(value);
+    expect(testFunc).toThrow('Path expression \'\' evaluated to "hello", but expected a boolean');
+    expect(testFunc).toThrow(StatesRuntimeError);
+  });
+});

--- a/__tests__/jsonPath/constraints/DefinedValueConstraint.test.ts
+++ b/__tests__/jsonPath/constraints/DefinedValueConstraint.test.ts
@@ -1,0 +1,27 @@
+import { DefinedValueConstraint } from '../../../src/stateMachine/jsonPath/constraints/DefinedValueConstraint';
+import { StatesRuntimeError } from '../../../src/error/predefined/StatesRuntimeError';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('DefinedValueConstraint', () => {
+  test('should not throw if passed value is not undefined', () => {
+    const value = {};
+
+    const constraint = new DefinedValueConstraint('');
+
+    const testFunc = () => constraint.test(value);
+    expect(testFunc).not.toThrow();
+  });
+
+  test('should throw if passed value is undefined', () => {
+    const value = undefined;
+
+    const constraint = new DefinedValueConstraint('');
+
+    const testFunc = () => constraint.test(value);
+    expect(testFunc).toThrow("Path expression '' does not point to a value");
+    expect(testFunc).toThrow(StatesRuntimeError);
+  });
+});

--- a/__tests__/jsonPath/constraints/IntegerConstraint.test.ts
+++ b/__tests__/jsonPath/constraints/IntegerConstraint.test.ts
@@ -1,0 +1,81 @@
+import { IntegerConstraint } from '../../../src/stateMachine/jsonPath/constraints/IntegerConstraint';
+import { StatesRuntimeError } from '../../../src/error/predefined/StatesRuntimeError';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('IntegerConstraint', () => {
+  test('should not throw if passed value is an integer', () => {
+    const value = 12345;
+
+    const constraint = new IntegerConstraint('');
+
+    const testFunc = () => constraint.test(value);
+    expect(testFunc).not.toThrow();
+  });
+
+  test('should throw if passed value is not a number', () => {
+    const value = 'hello, world!';
+
+    const constraint = new IntegerConstraint('');
+
+    const testFunc = () => constraint.test(value);
+    expect(testFunc).toThrow('Path expression \'\' evaluated to "hello, world!", but expected an integer');
+    expect(testFunc).toThrow(StatesRuntimeError);
+  });
+
+  test('should throw if passed value is a number but not an integer', () => {
+    const value = 123.45;
+
+    const constraint = new IntegerConstraint('');
+
+    const testFunc = () => constraint.test(value);
+    expect(testFunc).toThrow("Path expression '' evaluated to 123.45, but expected an integer");
+    expect(testFunc).toThrow(StatesRuntimeError);
+  });
+
+  describe('IntegerConstraint.greaterThanOrEqual', () => {
+    test('should not throw if passed value is greater than the constraint value', () => {
+      const value = 12345;
+
+      const GreaterThanOrEqualConstraint = IntegerConstraint.greaterThanOrEqual(12000);
+      const constraint = new GreaterThanOrEqualConstraint('');
+
+      const testFunc = () => constraint.test(value);
+      expect(testFunc).not.toThrow();
+    });
+
+    test('should not throw if passed value is equal to the constraint value', () => {
+      const value = 12345;
+
+      const GreaterThanOrEqualConstraint = IntegerConstraint.greaterThanOrEqual(12345);
+      const constraint = new GreaterThanOrEqualConstraint('');
+
+      const testFunc = () => constraint.test(value);
+      expect(testFunc).not.toThrow();
+    });
+
+    test('should throw if passed value is less than the constraint value', () => {
+      const value = 8000;
+
+      const GreaterThanOrEqualConstraint = IntegerConstraint.greaterThanOrEqual(12345);
+      const constraint = new GreaterThanOrEqualConstraint('');
+
+      const testFunc = () => constraint.test(value);
+      expect(testFunc).toThrow("Path expression '' evaluated to 8000, but expected an integer >= 12345");
+      expect(testFunc).toThrow(StatesRuntimeError);
+    });
+
+    test('should throw if passed value is not an integer', () => {
+      const value = 123.45;
+
+      const GreaterThanOrEqualConstraint = IntegerConstraint.greaterThanOrEqual(12345);
+      const constraint = new GreaterThanOrEqualConstraint('');
+
+      const testFunc = () => constraint.test(value);
+      expect(testFunc).toThrow("Path expression '' evaluated to 123.45, but expected an integer");
+      expect(testFunc).toThrow(StatesRuntimeError);
+    });
+  });
+});

--- a/__tests__/jsonPath/constraints/NumberConstraint.test.ts
+++ b/__tests__/jsonPath/constraints/NumberConstraint.test.ts
@@ -1,0 +1,27 @@
+import { NumberConstraint } from '../../../src/stateMachine/jsonPath/constraints/NumberConstraint';
+import { StatesRuntimeError } from '../../../src/error/predefined/StatesRuntimeError';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('NumberConstraint', () => {
+  test('should not throw if passed value is a number', () => {
+    const value = 3.1415926535;
+
+    const constraint = new NumberConstraint('');
+
+    const testFunc = () => constraint.test(value);
+    expect(testFunc).not.toThrow();
+  });
+
+  test('should throw if passed value is not a number', () => {
+    const value = 'hello';
+
+    const constraint = new NumberConstraint('');
+
+    const testFunc = () => constraint.test(value);
+    expect(testFunc).toThrow('Path expression \'\' evaluated to "hello", but expected a number');
+    expect(testFunc).toThrow(StatesRuntimeError);
+  });
+});

--- a/__tests__/jsonPath/constraints/RFC3339TimestampConstraint.test.ts
+++ b/__tests__/jsonPath/constraints/RFC3339TimestampConstraint.test.ts
@@ -1,0 +1,41 @@
+import { RFC3339TimestampConstraint } from '../../../src/stateMachine/jsonPath/constraints/RFC3339TimestampConstraint';
+import { StatesRuntimeError } from '../../../src/error/predefined/StatesRuntimeError';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('RFC3339TimestampConstraint', () => {
+  test('should not throw if passed value is a timestamp', () => {
+    const value = '2023-09-15T20:45:30-06:00';
+
+    const constraint = new RFC3339TimestampConstraint('');
+
+    const testFunc = () => constraint.test(value);
+    expect(testFunc).not.toThrow();
+  });
+
+  test('should throw if passed value is not a string', () => {
+    const value = {};
+
+    const constraint = new RFC3339TimestampConstraint('');
+
+    const testFunc = () => constraint.test(value);
+    expect(testFunc).toThrow(
+      "Path expression '' evaluated to {}, but expected a timestamp conforming to the RFC3339 profile"
+    );
+    expect(testFunc).toThrow(StatesRuntimeError);
+  });
+
+  test('should throw if passed value is not a date conforming to the RFC3339 profile', () => {
+    const value = 'not a valid timestamp';
+
+    const constraint = new RFC3339TimestampConstraint('');
+
+    const testFunc = () => constraint.test(value);
+    expect(testFunc).toThrow(
+      'Path expression \'\' evaluated to "not a valid timestamp", but expected a timestamp conforming to the RFC3339 profile'
+    );
+    expect(testFunc).toThrow(StatesRuntimeError);
+  });
+});

--- a/__tests__/jsonPath/constraints/StringConstraint.test.ts
+++ b/__tests__/jsonPath/constraints/StringConstraint.test.ts
@@ -1,0 +1,27 @@
+import { StringConstraint } from '../../../src/stateMachine/jsonPath/constraints/StringConstraint';
+import { StatesRuntimeError } from '../../../src/error/predefined/StatesRuntimeError';
+
+afterEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('StringConstraint', () => {
+  test('should not throw if passed value is a string', () => {
+    const value = 'hello';
+
+    const constraint = new StringConstraint('');
+
+    const testFunc = () => constraint.test(value);
+    expect(testFunc).not.toThrow();
+  });
+
+  test('should throw if passed value is not a string', () => {
+    const value = {};
+
+    const constraint = new StringConstraint('');
+
+    const testFunc = () => constraint.test(value);
+    expect(testFunc).toThrow("Path expression '' evaluated to {}, but expected a string");
+    expect(testFunc).toThrow(StatesRuntimeError);
+  });
+});

--- a/__tests__/stateActions/ChoiceStateAction.test.ts
+++ b/__tests__/stateActions/ChoiceStateAction.test.ts
@@ -770,6 +770,148 @@ describe('Choice State', () => {
     });
   });
 
+  describe('Path expression operators', () => {
+    const rules = [
+      {
+        rule: 'StringEqualsPath',
+        ruleValue: '$.comparisonValue',
+        inputValue: 'hello',
+        comparisonValue: 12345,
+        expectedType: 'string',
+      },
+      {
+        rule: 'StringLessThanPath',
+        ruleValue: '$.comparisonValue',
+        inputValue: 'a',
+        comparisonValue: true,
+        expectedType: 'string',
+      },
+      {
+        rule: 'StringGreaterThanPath',
+        ruleValue: '$.comparisonValue',
+        inputValue: 'b',
+        comparisonValue: {},
+        expectedType: 'string',
+      },
+      {
+        rule: 'StringLessThanEqualsPath',
+        ruleValue: '$.comparisonValue',
+        inputValue: 'a',
+        comparisonValue: [],
+        expectedType: 'string',
+      },
+      {
+        rule: 'StringGreaterThanEqualsPath',
+        ruleValue: '$.comparisonValue',
+        inputValue: 'c',
+        comparisonValue: 1.2345,
+        expectedType: 'string',
+      },
+      {
+        rule: 'NumericEqualsPath',
+        ruleValue: '$.comparisonValue',
+        inputValue: 10,
+        comparisonValue: 'hello',
+        expectedType: 'number',
+      },
+      {
+        rule: 'NumericLessThanPath',
+        ruleValue: '$.comparisonValue',
+        inputValue: 100,
+        comparisonValue: false,
+        expectedType: 'number',
+      },
+      {
+        rule: 'NumericGreaterThanPath',
+        ruleValue: '$.comparisonValue',
+        inputValue: 200,
+        comparisonValue: {},
+        expectedType: 'number',
+      },
+      {
+        rule: 'NumericLessThanEqualsPath',
+        ruleValue: '$.comparisonValue',
+        inputValue: 100,
+        comparisonValue: [],
+        expectedType: 'number',
+      },
+      {
+        rule: 'NumericGreaterThanEqualsPath',
+        ruleValue: '$.comparisonValue',
+        inputValue: 200,
+        comparisonValue: 'hello',
+        expectedType: 'number',
+      },
+      {
+        rule: 'BooleanEqualsPath',
+        ruleValue: '$.comparisonValue',
+        inputValue: true,
+        comparisonValue: 12345,
+        expectedType: 'boolean',
+      },
+      {
+        rule: 'TimestampEqualsPath',
+        ruleValue: '$.comparisonValue',
+        inputValue: '2020-01-01T15:00:00Z',
+        comparisonValue: 'hello',
+        expectedType: 'timestamp',
+      },
+      {
+        rule: 'TimestampLessThanPath',
+        ruleValue: '$.comparisonValue',
+        inputValue: '2019-12-31T15:00:00Z',
+        comparisonValue: 12345,
+        expectedType: 'timestamp',
+      },
+      {
+        rule: 'TimestampGreaterThanPath',
+        ruleValue: '$.comparisonValue',
+        inputValue: '2020-12-12T15:00:00Z',
+        comparisonValue: false,
+        expectedType: 'timestamp',
+      },
+      {
+        rule: 'TimestampLessThanEqualsPath',
+        ruleValue: '$.comparisonValue',
+        inputValue: '2019-12-31T15:00:00Z',
+        comparisonValue: {},
+        expectedType: 'timestamp',
+      },
+      {
+        rule: 'TimestampGreaterThanEqualsPath',
+        ruleValue: '$.comparisonValue',
+        inputValue: '2020-12-12T15:00:00Z',
+        comparisonValue: [],
+        expectedType: 'timestamp',
+      },
+    ];
+
+    describe.each(rules)('$rule', ({ rule, ruleValue, inputValue, comparisonValue, expectedType }) => {
+      const testTitle = `should throw runtime error if path expression operator does not reference a \`${expectedType}\` value`;
+
+      test(testTitle, async () => {
+        const definition: ChoiceState = {
+          Type: 'Choice',
+          Choices: [
+            {
+              Variable: '$.test',
+              [rule]: ruleValue,
+              Next: 'MatchingChoice',
+            },
+          ],
+          Default: 'DefaultChoice',
+        };
+        const stateName = 'ChoiceState';
+        const input = { test: inputValue, comparisonValue };
+        const context = {};
+
+        const choiceStateAction = new ChoiceStateAction(definition, stateName);
+
+        await expect(() => choiceStateAction.execute(input, context)).rejects.toThrow();
+      });
+    });
+  });
+
   test('should return state that matches choice rule as next state', async () => {
     const definition: ChoiceState = {
       Type: 'Choice',

--- a/__tests__/stateActions/MapStateAction.test.ts
+++ b/__tests__/stateActions/MapStateAction.test.ts
@@ -203,7 +203,7 @@ describe('Map State', () => {
 
     await expect(mapStateResult).rejects.toThrow(StatesRuntimeError);
     await expect(mapStateResult).rejects.toThrow(
-      'Input of Map state must be an array or ItemsPath property must point to an array'
+      'Path expression \'$.items\' evaluated to "not an array", but expected an array'
     );
   });
 

--- a/__tests__/stateActions/WaitStateAction.test.ts
+++ b/__tests__/stateActions/WaitStateAction.test.ts
@@ -127,4 +127,50 @@ describe('Wait State', () => {
     expect(mockSleepFunction).toHaveBeenCalledWith(1500, abortSignal, rootAbortSignal);
     expect(stateResult).toEqual({ waitUntil: '2022-12-05T05:45:00Z' });
   });
+
+  test('should throw runtime error if `SecondsPath` evaluation does not reference an integer greater than or equal to 0', async () => {
+    const definition: WaitState = {
+      Type: 'Wait',
+      SecondsPath: '$.waitFor',
+      End: true,
+    };
+    const stateName = 'WaitState';
+    const input = { waitFor: -5 };
+    const context = {};
+    const abortSignal = new AbortController().signal;
+    const options = {
+      abortSignal,
+      rootAbortSignal: undefined,
+      waitTimeOverrideOption: undefined,
+    };
+
+    const waitStateAction = new WaitStateAction(definition, stateName);
+
+    await expect(() => waitStateAction.execute(input, context, options)).rejects.toThrow(
+      "Path expression '$.waitFor' evaluated to -5, but expected an integer >= 0"
+    );
+  });
+
+  test('should throw runtime error if `SecondsPath` evaluation does not reference an integer greater than or equal to 0', async () => {
+    const definition: WaitState = {
+      Type: 'Wait',
+      TimestampPath: '$.waitUntil',
+      End: true,
+    };
+    const stateName = 'WaitState';
+    const input = { waitUntil: 'not a valid timestamp' };
+    const context = {};
+    const abortSignal = new AbortController().signal;
+    const options = {
+      abortSignal,
+      rootAbortSignal: undefined,
+      waitTimeOverrideOption: undefined,
+    };
+
+    const waitStateAction = new WaitStateAction(definition, stateName);
+
+    await expect(() => waitStateAction.execute(input, context, options)).rejects.toThrow(
+      'Path expression \'$.waitUntil\' evaluated to "not a valid timestamp", but expected a timestamp conforming to the RFC3339 profile'
+    );
+  });
 });

--- a/__tests__/util/index.test.ts
+++ b/__tests__/util/index.test.ts
@@ -1,4 +1,4 @@
-import { isPlainObj, sleep, isRFC3339Date } from '../../src/util';
+import { isPlainObj, sleep, isRFC3339Timestamp } from '../../src/util';
 
 afterEach(() => {
   jest.clearAllMocks();
@@ -59,7 +59,7 @@ describe('Utils', () => {
     });
   });
 
-  describe('isRFC3339Date', () => {
+  describe('isRFC3339Timestamp', () => {
     const positiveCases = [
       '2023-09-15T18:25:25Z',
       '2023-01-01T00:30:55+06:00',
@@ -79,7 +79,7 @@ describe('Utils', () => {
 
     describe.each(positiveCases)('Positive tests', (dateStr) => {
       test(`should return true if timestamp ${dateStr} conforms to RFC3339 profile`, () => {
-        const result = isRFC3339Date(dateStr);
+        const result = isRFC3339Timestamp(dateStr);
 
         expect(result).toBe(true);
       });
@@ -90,6 +90,7 @@ describe('Utils', () => {
       '2023-09',
       '2023-09-15',
       '2023-09-15T',
+      '18:25:25',
       '2023-09-15T18',
       '2023-09-15T18:25',
       '2023-09-1518:25:25',
@@ -111,7 +112,7 @@ describe('Utils', () => {
 
     describe.each(negativeCases)('Negative tests', (dateStr) => {
       test(`should return false if timestamp ${dateStr} does not conform to RFC3339 profile`, () => {
-        const result = isRFC3339Date(dateStr);
+        const result = isRFC3339Timestamp(dateStr);
 
         expect(result).toBe(false);
       });

--- a/__tests__/util/index.test.ts
+++ b/__tests__/util/index.test.ts
@@ -1,4 +1,4 @@
-import { isPlainObj, sleep } from '../../src/util';
+import { isPlainObj, sleep, isRFC3339Date } from '../../src/util';
 
 afterEach(() => {
   jest.clearAllMocks();
@@ -56,6 +56,65 @@ describe('Utils', () => {
       rootAbortController.abort();
 
       await expect(sleepPromise).resolves.not.toThrow();
+    });
+  });
+
+  describe('isRFC3339Date', () => {
+    const positiveCases = [
+      '2023-09-15T18:25:25Z',
+      '2023-01-01T00:30:55+06:00',
+      '2023-02-05T06:12:18-06:00',
+      '2023-03-10T03:09:41+23:59',
+      '2023-04-15T23:59:59-23:59',
+      '2023-05-20T20:51:48+00:30',
+      '2023-06-25T12:07:36-00:30',
+      '2023-07-30T19:49:25.1234Z',
+      '2023-08-31T15:02:25.46195386+06:00',
+      '2023-09-24T01:23:25.5-06:00',
+      '2023-10-12T11:15:25.83+23:59',
+      '2023-11-16T09:20:25.956-23:59',
+      '2023-12-27T16:45:25.19864+00:30',
+      '2023-05-19T22:37:25.173064-00:30',
+    ];
+
+    describe.each(positiveCases)('Positive tests', (dateStr) => {
+      test(`should return true if timestamp ${dateStr} conforms to RFC3339 profile`, () => {
+        const result = isRFC3339Date(dateStr);
+
+        expect(result).toBe(true);
+      });
+    });
+
+    const negativeCases = [
+      '2023',
+      '2023-09',
+      '2023-09-15',
+      '2023-09-15T',
+      '2023-09-15T18',
+      '2023-09-15T18:25',
+      '2023-09-1518:25:25',
+      '2023-09-15T18:25:25',
+      '2023-13-01T00:30:55+06:00',
+      '2023-02-78T06:12:18-06:00',
+      '2023-03-10T24:09:41+23:59',
+      '2023-04-15T23:60:99-23:59',
+      '2023-05-20T20:51:48+35:30',
+      '2023-06-25T12:07:36-00:65',
+      '2023-07-30T19:49:25:1234Z',
+      '2023-08-31T15:02:25.46195386Z+06.00',
+      '2023-09-24T01:23:25.5-06:00Z',
+      '500-10-12T11:15:25.83+23:59',
+      '2023-11-16-09:20:25.956-23:59',
+      '2023-12-27T16:45:25.19864+00',
+      '2023-05-19T22:37:25.173064.00:30',
+    ];
+
+    describe.each(negativeCases)('Negative tests', (dateStr) => {
+      test(`should return false if timestamp ${dateStr} does not conform to RFC3339 profile`, () => {
+        const result = isRFC3339Date(dateStr);
+
+        expect(result).toBe(false);
+      });
     });
   });
 });

--- a/src/stateMachine/InputOutputProcessing.ts
+++ b/src/stateMachine/InputOutputProcessing.ts
@@ -2,7 +2,7 @@ import type { PayloadTemplate } from '../typings/InputOutputProcessing';
 import type { JSONValue } from '../typings/JSONValue';
 import type { Context } from '../typings/Context';
 import { isPlainObj } from '../util';
-import { jsonPathQuery } from './JsonPath';
+import { jsonPathQuery } from './jsonPath/JsonPath';
 import { StatesResultPathMatchFailureError } from '../error/predefined/StatesResultPathMatchFailureError';
 import { evaluateIntrinsicFunction } from './IntrinsicFunctionEvaluation';
 import cloneDeep from 'lodash/cloneDeep.js';

--- a/src/stateMachine/InputOutputProcessing.ts
+++ b/src/stateMachine/InputOutputProcessing.ts
@@ -15,7 +15,7 @@ import set from 'lodash/set.js';
  * * If `InputPath` is `null`, returns an empty object (`{}`).
  * * If `InputPath` is a string, it's considered a JSONPath and the selected portion of the current input is returned.
  */
-function processInputPath(path: string | null | undefined, input: JSONValue, context?: Context): JSONValue {
+function processInputPath(path: string | null | undefined, input: JSONValue, context: Context): JSONValue {
   if (path === undefined) {
     return input;
   }
@@ -34,7 +34,7 @@ function processInputPath(path: string | null | undefined, input: JSONValue, con
  * @param context The context object to evaluate, if the path expression starts with `$$`.
  * @returns The processed payload template.
  */
-function processPayloadTemplate(payloadTemplate: PayloadTemplate, json: JSONValue, context?: Context): PayloadTemplate {
+function processPayloadTemplate(payloadTemplate: PayloadTemplate, json: JSONValue, context: Context): PayloadTemplate {
   const resolvedProperties = Object.entries(payloadTemplate).map(([key, value]) => {
     let sanitizedKey = key;
     let resolvedValue = value;
@@ -98,7 +98,7 @@ function processResultPath(path: string | null | undefined, rawInput: JSONValue,
  * * If `OutputPath` is `null`, returns an empty object (`{}`).
  * * If `OutputPath` is a string, it's considered a JSONPath and the selected portion of the current result is returned.
  */
-function processOutputPath(path: string | null | undefined, result: JSONValue, context?: Context): JSONValue {
+function processOutputPath(path: string | null | undefined, result: JSONValue, context: Context): JSONValue {
   if (path === undefined) {
     return result;
   }

--- a/src/stateMachine/IntrinsicFunctionEvaluation.ts
+++ b/src/stateMachine/IntrinsicFunctionEvaluation.ts
@@ -46,7 +46,7 @@ const functions: Record<IntrinsicFunctionName, BaseIntrinsicFunction> = {
  * Evaluate an intrinsic function. Any nested (however deeply) intrinsic functions also get evaluated.
  * @returns The result of the intrinsic function evaluation.
  */
-export function evaluateIntrinsicFunction(intrinsicFunction: string, input: JSONValue, context?: Context): JSONValue {
+export function evaluateIntrinsicFunction(intrinsicFunction: string, input: JSONValue, context: Context): JSONValue {
   const openingParensIdx = intrinsicFunction.indexOf('(');
   const funcName = intrinsicFunction.slice(0, openingParensIdx) as IntrinsicFunctionName;
   const funcArgs = intrinsicFunction.slice(openingParensIdx + 1, intrinsicFunction.length - 1);

--- a/src/stateMachine/intrinsicFunctions/ArgumentHandling.ts
+++ b/src/stateMachine/intrinsicFunctions/ArgumentHandling.ts
@@ -127,7 +127,7 @@ function validateArguments(funcDefinition: IntrinsicFunctionDefinition, ...args:
   }
 }
 
-function parseArguments(input: JSONValue, context?: Context, ...args: string[]): JSONValue[] {
+function parseArguments(input: JSONValue, context: Context, ...args: string[]): JSONValue[] {
   return args.map<JSONValue>((arg) => {
     if (arg[0] === "'") {
       const lastSingleQuote = arg.lastIndexOf("'");

--- a/src/stateMachine/intrinsicFunctions/ArgumentHandling.ts
+++ b/src/stateMachine/intrinsicFunctions/ArgumentHandling.ts
@@ -6,7 +6,7 @@ import type {
 import type { Context } from '../../typings/Context';
 import type { JSONValue } from '../../typings/JSONValue';
 import { StatesRuntimeError } from '../../error/predefined/StatesRuntimeError';
-import { jsonPathQuery } from '../JsonPath';
+import { jsonPathQuery } from '../jsonPath/JsonPath';
 import { isPlainObj } from '../../util';
 
 function validateArgumentType(allowedTypes: ArgumentType[], argPosition: number, funcArg: JSONValue, funcName: string) {

--- a/src/stateMachine/intrinsicFunctions/BaseIntrinsicFunction.ts
+++ b/src/stateMachine/intrinsicFunctions/BaseIntrinsicFunction.ts
@@ -8,7 +8,7 @@ abstract class BaseIntrinsicFunction {
 
   protected abstract execute(...args: JSONValue[]): JSONValue;
 
-  call(input: JSONValue, context?: Context, ...args: string[]): JSONValue {
+  call(input: JSONValue, context: Context, ...args: string[]): JSONValue {
     const parsedArgs = parseArguments(input, context, ...args);
     validateArguments(this.funcDefinition, ...parsedArgs);
 

--- a/src/stateMachine/jsonPath/JsonPath.ts
+++ b/src/stateMachine/jsonPath/JsonPath.ts
@@ -9,7 +9,7 @@ import { DefinedValueConstraint } from './constraints/DefinedValueConstraint';
  * @param pathExpression The JSONPath expression to query for.
  * @param json The object to evaluate (whether of null, boolean, number, string, object, or array type).
  * @param context The context object to evaluate, if the path expression starts with `$$`.
- * @param constraints Optional array of constraints that check if the result of the evaluation complies with the constraints.
+ * @param constraints Optional array of constraints that check if the result of the evaluation fulfills the restrictions set by the constraints.
  * @returns The value of the property that was queried for, if found. Otherwise returns `undefined`.
  */
 function jsonPathQuery<T>(

--- a/src/stateMachine/jsonPath/JsonPath.ts
+++ b/src/stateMachine/jsonPath/JsonPath.ts
@@ -9,7 +9,7 @@ import { JSONPath as jp } from 'jsonpath-plus';
  * @param context The context object to evaluate, if the path expression starts with `$$`.
  * @returns The value of the property that was queried for, if found. Otherwise returns `undefined`.
  */
-function jsonPathQuery<T>(pathExpression: string, json: JSONValue, context?: Context): T {
+function jsonPathQuery<T>(pathExpression: string, json: JSONValue, context: Context): T {
   // If the expression starts with double `$$`, evaluate the path in the context object.
   if (pathExpression.startsWith('$$')) {
     return jp({ path: pathExpression.slice(1), json: context ?? null, wrap: false });

--- a/src/stateMachine/jsonPath/JsonPath.ts
+++ b/src/stateMachine/jsonPath/JsonPath.ts
@@ -1,21 +1,40 @@
+import type { BaseJSONPathConstraint } from './constraints/BaseJsonPathConstraint';
 import type { JSONValue } from '../../typings/JSONValue';
 import type { Context } from '../../typings/Context';
 import { JSONPath as jp } from 'jsonpath-plus';
+import { DefinedValueConstraint } from './constraints/DefinedValueConstraint';
 
 /**
  * Queries for a property in an object or in the context object of a state machine using a JSONPath expression.
  * @param pathExpression The JSONPath expression to query for.
  * @param json The object to evaluate (whether of null, boolean, number, string, object, or array type).
  * @param context The context object to evaluate, if the path expression starts with `$$`.
+ * @param constraints Optional array of constraints that check if the result of the evaluation complies with the constraints.
  * @returns The value of the property that was queried for, if found. Otherwise returns `undefined`.
  */
-function jsonPathQuery<T>(pathExpression: string, json: JSONValue, context: Context): T {
+function jsonPathQuery<T>(
+  pathExpression: string,
+  json: JSONValue,
+  context: Context,
+  constraints: (new (...params: ConstructorParameters<typeof BaseJSONPathConstraint>) => BaseJSONPathConstraint)[] = []
+): T {
+  // All JSONPaths must point to a defined value
+  const defaultConstraints = [DefinedValueConstraint];
+  let evaluation: T;
+
   // If the expression starts with double `$$`, evaluate the path in the context object.
   if (pathExpression.startsWith('$$')) {
-    return jp({ path: pathExpression.slice(1), json: context ?? null, wrap: false });
+    evaluation = jp({ path: pathExpression.slice(1), json: context ?? null, wrap: false });
+  } else {
+    evaluation = jp({ path: pathExpression, json, wrap: false });
   }
 
-  return jp({ path: pathExpression, json, wrap: false });
+  for (const Constraint of [...defaultConstraints, ...constraints]) {
+    const constraintObject = new Constraint(pathExpression);
+    constraintObject.test(evaluation);
+  }
+
+  return evaluation;
 }
 
 export { jsonPathQuery };

--- a/src/stateMachine/jsonPath/JsonPath.ts
+++ b/src/stateMachine/jsonPath/JsonPath.ts
@@ -1,5 +1,5 @@
-import type { JSONValue } from '../typings/JSONValue';
-import type { Context } from '../typings/Context';
+import type { JSONValue } from '../../typings/JSONValue';
+import type { Context } from '../../typings/Context';
 import { JSONPath as jp } from 'jsonpath-plus';
 
 /**

--- a/src/stateMachine/jsonPath/constraints/ArrayConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/ArrayConstraint.ts
@@ -1,12 +1,12 @@
 import { BaseJSONPathConstraint } from './BaseJsonPathConstraint';
 import { StatesRuntimeError } from '../../../error/predefined/StatesRuntimeError';
-import { quoteJSONValue } from '../../../util';
+import { stringifyJSONValue } from '../../../util';
 
 export class ArrayConstraint extends BaseJSONPathConstraint {
   test(value: unknown): void {
     if (!Array.isArray(value)) {
       throw new StatesRuntimeError(
-        `Path expression '${this.pathExpression}' evaluated to ${quoteJSONValue(value)}, but expected an array`
+        `Path expression '${this.pathExpression}' evaluated to ${stringifyJSONValue(value)}, but expected an array`
       );
     }
   }

--- a/src/stateMachine/jsonPath/constraints/ArrayConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/ArrayConstraint.ts
@@ -1,0 +1,12 @@
+import { BaseJSONPathConstraint } from './BaseJsonPathConstraint';
+import { StatesRuntimeError } from '../../../error/predefined/StatesRuntimeError';
+
+export class ArrayConstraint extends BaseJSONPathConstraint {
+  test(value: unknown): void {
+    if (!Array.isArray(value)) {
+      throw new StatesRuntimeError(
+        `JSONPath expression '${this.pathExpression}' evaluated to ${value}, but expected an array`
+      );
+    }
+  }
+}

--- a/src/stateMachine/jsonPath/constraints/ArrayConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/ArrayConstraint.ts
@@ -6,7 +6,7 @@ export class ArrayConstraint extends BaseJSONPathConstraint {
   test(value: unknown): void {
     if (!Array.isArray(value)) {
       throw new StatesRuntimeError(
-        `JSONPath expression '${this.pathExpression}' evaluated to ${quoteJSONValue(value)}, but expected an array`
+        `Path expression '${this.pathExpression}' evaluated to ${quoteJSONValue(value)}, but expected an array`
       );
     }
   }

--- a/src/stateMachine/jsonPath/constraints/ArrayConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/ArrayConstraint.ts
@@ -1,11 +1,12 @@
 import { BaseJSONPathConstraint } from './BaseJsonPathConstraint';
 import { StatesRuntimeError } from '../../../error/predefined/StatesRuntimeError';
+import { quoteJSONValue } from '../../../util';
 
 export class ArrayConstraint extends BaseJSONPathConstraint {
   test(value: unknown): void {
     if (!Array.isArray(value)) {
       throw new StatesRuntimeError(
-        `JSONPath expression '${this.pathExpression}' evaluated to ${value}, but expected an array`
+        `JSONPath expression '${this.pathExpression}' evaluated to ${quoteJSONValue(value)}, but expected an array`
       );
     }
   }

--- a/src/stateMachine/jsonPath/constraints/BaseJsonPathConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/BaseJsonPathConstraint.ts
@@ -1,0 +1,9 @@
+export abstract class BaseJSONPathConstraint {
+  protected pathExpression: string;
+
+  constructor(pathExpression: string) {
+    this.pathExpression = pathExpression;
+  }
+
+  abstract test(value: unknown): void;
+}

--- a/src/stateMachine/jsonPath/constraints/BooleanConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/BooleanConstraint.ts
@@ -6,7 +6,7 @@ export class BooleanConstraint extends BaseJSONPathConstraint {
   test(value: unknown): void {
     if (typeof value !== 'boolean') {
       throw new StatesRuntimeError(
-        `JSONPath expression '${this.pathExpression}' evaluated to ${quoteJSONValue(value)}, but expected a boolean`
+        `Path expression '${this.pathExpression}' evaluated to ${quoteJSONValue(value)}, but expected a boolean`
       );
     }
   }

--- a/src/stateMachine/jsonPath/constraints/BooleanConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/BooleanConstraint.ts
@@ -1,11 +1,12 @@
 import { BaseJSONPathConstraint } from './BaseJsonPathConstraint';
 import { StatesRuntimeError } from '../../../error/predefined/StatesRuntimeError';
+import { quoteJSONValue } from '../../../util';
 
 export class BooleanConstraint extends BaseJSONPathConstraint {
   test(value: unknown): void {
     if (typeof value !== 'boolean') {
       throw new StatesRuntimeError(
-        `JSONPath expression '${this.pathExpression}' evaluated to ${value}, but expected a boolean`
+        `JSONPath expression '${this.pathExpression}' evaluated to ${quoteJSONValue(value)}, but expected a boolean`
       );
     }
   }

--- a/src/stateMachine/jsonPath/constraints/BooleanConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/BooleanConstraint.ts
@@ -1,0 +1,12 @@
+import { BaseJSONPathConstraint } from './BaseJsonPathConstraint';
+import { StatesRuntimeError } from '../../../error/predefined/StatesRuntimeError';
+
+export class BooleanConstraint extends BaseJSONPathConstraint {
+  test(value: unknown): void {
+    if (typeof value !== 'boolean') {
+      throw new StatesRuntimeError(
+        `JSONPath expression '${this.pathExpression}' evaluated to ${value}, but expected a boolean`
+      );
+    }
+  }
+}

--- a/src/stateMachine/jsonPath/constraints/BooleanConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/BooleanConstraint.ts
@@ -1,12 +1,12 @@
 import { BaseJSONPathConstraint } from './BaseJsonPathConstraint';
 import { StatesRuntimeError } from '../../../error/predefined/StatesRuntimeError';
-import { quoteJSONValue } from '../../../util';
+import { stringifyJSONValue } from '../../../util';
 
 export class BooleanConstraint extends BaseJSONPathConstraint {
   test(value: unknown): void {
     if (typeof value !== 'boolean') {
       throw new StatesRuntimeError(
-        `Path expression '${this.pathExpression}' evaluated to ${quoteJSONValue(value)}, but expected a boolean`
+        `Path expression '${this.pathExpression}' evaluated to ${stringifyJSONValue(value)}, but expected a boolean`
       );
     }
   }

--- a/src/stateMachine/jsonPath/constraints/DefinedValueConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/DefinedValueConstraint.ts
@@ -1,0 +1,10 @@
+import { BaseJSONPathConstraint } from './BaseJsonPathConstraint';
+import { StatesRuntimeError } from '../../../error/predefined/StatesRuntimeError';
+
+export class DefinedValueConstraint extends BaseJSONPathConstraint {
+  test(value: unknown): void {
+    if (typeof value === 'undefined') {
+      throw new StatesRuntimeError(`JSONPath expression '${this.pathExpression}' does not point to a value`);
+    }
+  }
+}

--- a/src/stateMachine/jsonPath/constraints/DefinedValueConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/DefinedValueConstraint.ts
@@ -4,7 +4,7 @@ import { StatesRuntimeError } from '../../../error/predefined/StatesRuntimeError
 export class DefinedValueConstraint extends BaseJSONPathConstraint {
   test(value: unknown): void {
     if (typeof value === 'undefined') {
-      throw new StatesRuntimeError(`JSONPath expression '${this.pathExpression}' does not point to a value`);
+      throw new StatesRuntimeError(`Path expression '${this.pathExpression}' does not point to a value`);
     }
   }
 }

--- a/src/stateMachine/jsonPath/constraints/IntegerConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/IntegerConstraint.ts
@@ -6,7 +6,7 @@ export class IntegerConstraint extends BaseJSONPathConstraint {
   test(value: unknown): void {
     if (!Number.isInteger(value)) {
       throw new StatesRuntimeError(
-        `JSONPath expression '${this.pathExpression}' evaluated to ${quoteJSONValue(value)}, but expected an integer`
+        `Path expression '${this.pathExpression}' evaluated to ${quoteJSONValue(value)}, but expected an integer`
       );
     }
   }
@@ -18,7 +18,7 @@ export class IntegerConstraint extends BaseJSONPathConstraint {
 
         if (value < n) {
           throw new StatesRuntimeError(
-            `JSONPath expression '${this.pathExpression}' evaluated to ${quoteJSONValue(
+            `Path expression '${this.pathExpression}' evaluated to ${quoteJSONValue(
               value
             )}, but expected an integer >= ${n}`
           );

--- a/src/stateMachine/jsonPath/constraints/IntegerConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/IntegerConstraint.ts
@@ -1,11 +1,12 @@
 import { BaseJSONPathConstraint } from './BaseJsonPathConstraint';
 import { StatesRuntimeError } from '../../../error/predefined/StatesRuntimeError';
+import { quoteJSONValue } from '../../../util';
 
 export class IntegerConstraint extends BaseJSONPathConstraint {
   test(value: unknown): void {
     if (!Number.isInteger(value)) {
       throw new StatesRuntimeError(
-        `JSONPath expression '${this.pathExpression}' evaluated to ${value}, but expected an integer`
+        `JSONPath expression '${this.pathExpression}' evaluated to ${quoteJSONValue(value)}, but expected an integer`
       );
     }
   }
@@ -17,7 +18,9 @@ export class IntegerConstraint extends BaseJSONPathConstraint {
 
         if (value < n) {
           throw new StatesRuntimeError(
-            `JSONPath expression '${this.pathExpression}' evaluated to ${value}, but expected an integer >= ${n}`
+            `JSONPath expression '${this.pathExpression}' evaluated to ${quoteJSONValue(
+              value
+            )}, but expected an integer >= ${n}`
           );
         }
       }

--- a/src/stateMachine/jsonPath/constraints/IntegerConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/IntegerConstraint.ts
@@ -1,0 +1,26 @@
+import { BaseJSONPathConstraint } from './BaseJsonPathConstraint';
+import { StatesRuntimeError } from '../../../error/predefined/StatesRuntimeError';
+
+export class IntegerConstraint extends BaseJSONPathConstraint {
+  test(value: unknown): void {
+    if (!Number.isInteger(value)) {
+      throw new StatesRuntimeError(
+        `JSONPath expression '${this.pathExpression}' evaluated to ${value}, but expected an integer`
+      );
+    }
+  }
+
+  static greaterThanOrEqual(n: number): typeof IntegerConstraint {
+    return class extends this {
+      override test(value: number): void {
+        super.test(value);
+
+        if (value < n) {
+          throw new StatesRuntimeError(
+            `JSONPath expression '${this.pathExpression}' evaluated to ${value}, but expected an integer >= ${n}`
+          );
+        }
+      }
+    };
+  }
+}

--- a/src/stateMachine/jsonPath/constraints/IntegerConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/IntegerConstraint.ts
@@ -1,12 +1,12 @@
 import { BaseJSONPathConstraint } from './BaseJsonPathConstraint';
 import { StatesRuntimeError } from '../../../error/predefined/StatesRuntimeError';
-import { quoteJSONValue } from '../../../util';
+import { stringifyJSONValue } from '../../../util';
 
 export class IntegerConstraint extends BaseJSONPathConstraint {
   test(value: unknown): void {
     if (!Number.isInteger(value)) {
       throw new StatesRuntimeError(
-        `Path expression '${this.pathExpression}' evaluated to ${quoteJSONValue(value)}, but expected an integer`
+        `Path expression '${this.pathExpression}' evaluated to ${stringifyJSONValue(value)}, but expected an integer`
       );
     }
   }
@@ -18,7 +18,7 @@ export class IntegerConstraint extends BaseJSONPathConstraint {
 
         if (value < n) {
           throw new StatesRuntimeError(
-            `Path expression '${this.pathExpression}' evaluated to ${quoteJSONValue(
+            `Path expression '${this.pathExpression}' evaluated to ${stringifyJSONValue(
               value
             )}, but expected an integer >= ${n}`
           );

--- a/src/stateMachine/jsonPath/constraints/NumberConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/NumberConstraint.ts
@@ -6,7 +6,7 @@ export class NumberConstraint extends BaseJSONPathConstraint {
   test(value: unknown): void {
     if (typeof value !== 'number') {
       throw new StatesRuntimeError(
-        `JSONPath expression '${this.pathExpression}' evaluated to ${quoteJSONValue(value)}, but expected a number`
+        `Path expression '${this.pathExpression}' evaluated to ${quoteJSONValue(value)}, but expected a number`
       );
     }
   }

--- a/src/stateMachine/jsonPath/constraints/NumberConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/NumberConstraint.ts
@@ -1,0 +1,12 @@
+import { BaseJSONPathConstraint } from './BaseJsonPathConstraint';
+import { StatesRuntimeError } from '../../../error/predefined/StatesRuntimeError';
+
+export class NumberConstraint extends BaseJSONPathConstraint {
+  test(value: unknown): void {
+    if (typeof value !== 'number') {
+      throw new StatesRuntimeError(
+        `JSONPath expression '${this.pathExpression}' evaluated to ${value}, but expected a number`
+      );
+    }
+  }
+}

--- a/src/stateMachine/jsonPath/constraints/NumberConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/NumberConstraint.ts
@@ -1,11 +1,12 @@
 import { BaseJSONPathConstraint } from './BaseJsonPathConstraint';
 import { StatesRuntimeError } from '../../../error/predefined/StatesRuntimeError';
+import { quoteJSONValue } from '../../../util';
 
 export class NumberConstraint extends BaseJSONPathConstraint {
   test(value: unknown): void {
     if (typeof value !== 'number') {
       throw new StatesRuntimeError(
-        `JSONPath expression '${this.pathExpression}' evaluated to ${value}, but expected a number`
+        `JSONPath expression '${this.pathExpression}' evaluated to ${quoteJSONValue(value)}, but expected a number`
       );
     }
   }

--- a/src/stateMachine/jsonPath/constraints/NumberConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/NumberConstraint.ts
@@ -1,12 +1,12 @@
 import { BaseJSONPathConstraint } from './BaseJsonPathConstraint';
 import { StatesRuntimeError } from '../../../error/predefined/StatesRuntimeError';
-import { quoteJSONValue } from '../../../util';
+import { stringifyJSONValue } from '../../../util';
 
 export class NumberConstraint extends BaseJSONPathConstraint {
   test(value: unknown): void {
     if (typeof value !== 'number') {
       throw new StatesRuntimeError(
-        `Path expression '${this.pathExpression}' evaluated to ${quoteJSONValue(value)}, but expected a number`
+        `Path expression '${this.pathExpression}' evaluated to ${stringifyJSONValue(value)}, but expected a number`
       );
     }
   }

--- a/src/stateMachine/jsonPath/constraints/RFC3339TimestampConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/RFC3339TimestampConstraint.ts
@@ -1,12 +1,14 @@
 import { BaseJSONPathConstraint } from './BaseJsonPathConstraint';
-import { isRFC3339Date } from '../../../util';
+import { isRFC3339Date, quoteJSONValue } from '../../../util';
 import { StatesRuntimeError } from '../../../error/predefined/StatesRuntimeError';
 
 export class RFC3339TimestampConstraint extends BaseJSONPathConstraint {
   test(value: unknown): void {
     if (typeof value !== 'string' || !isRFC3339Date(value)) {
       throw new StatesRuntimeError(
-        `JSONPath expression '${this.pathExpression}' evaluated to ${value}, but expected a timestamp conforming to the RFC3339 profile`
+        `JSONPath expression '${this.pathExpression}' evaluated to ${quoteJSONValue(
+          value
+        )}, but expected a timestamp conforming to the RFC3339 profile`
       );
     }
   }

--- a/src/stateMachine/jsonPath/constraints/RFC3339TimestampConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/RFC3339TimestampConstraint.ts
@@ -1,0 +1,13 @@
+import { BaseJSONPathConstraint } from './BaseJsonPathConstraint';
+import { isRFC3339Date } from '../../../util';
+import { StatesRuntimeError } from '../../../error/predefined/StatesRuntimeError';
+
+export class RFC3339TimestampConstraint extends BaseJSONPathConstraint {
+  test(value: unknown): void {
+    if (typeof value !== 'string' || !isRFC3339Date(value)) {
+      throw new StatesRuntimeError(
+        `JSONPath expression '${this.pathExpression}' evaluated to ${value}, but expected a timestamp conforming to the RFC3339 profile`
+      );
+    }
+  }
+}

--- a/src/stateMachine/jsonPath/constraints/RFC3339TimestampConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/RFC3339TimestampConstraint.ts
@@ -1,10 +1,10 @@
 import { BaseJSONPathConstraint } from './BaseJsonPathConstraint';
-import { isRFC3339Date, stringifyJSONValue } from '../../../util';
+import { isRFC3339Timestamp, stringifyJSONValue } from '../../../util';
 import { StatesRuntimeError } from '../../../error/predefined/StatesRuntimeError';
 
 export class RFC3339TimestampConstraint extends BaseJSONPathConstraint {
   test(value: unknown): void {
-    if (typeof value !== 'string' || !isRFC3339Date(value)) {
+    if (typeof value !== 'string' || !isRFC3339Timestamp(value)) {
       throw new StatesRuntimeError(
         `Path expression '${this.pathExpression}' evaluated to ${stringifyJSONValue(
           value

--- a/src/stateMachine/jsonPath/constraints/RFC3339TimestampConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/RFC3339TimestampConstraint.ts
@@ -1,12 +1,12 @@
 import { BaseJSONPathConstraint } from './BaseJsonPathConstraint';
-import { isRFC3339Date, quoteJSONValue } from '../../../util';
+import { isRFC3339Date, stringifyJSONValue } from '../../../util';
 import { StatesRuntimeError } from '../../../error/predefined/StatesRuntimeError';
 
 export class RFC3339TimestampConstraint extends BaseJSONPathConstraint {
   test(value: unknown): void {
     if (typeof value !== 'string' || !isRFC3339Date(value)) {
       throw new StatesRuntimeError(
-        `Path expression '${this.pathExpression}' evaluated to ${quoteJSONValue(
+        `Path expression '${this.pathExpression}' evaluated to ${stringifyJSONValue(
           value
         )}, but expected a timestamp conforming to the RFC3339 profile`
       );

--- a/src/stateMachine/jsonPath/constraints/RFC3339TimestampConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/RFC3339TimestampConstraint.ts
@@ -6,7 +6,7 @@ export class RFC3339TimestampConstraint extends BaseJSONPathConstraint {
   test(value: unknown): void {
     if (typeof value !== 'string' || !isRFC3339Date(value)) {
       throw new StatesRuntimeError(
-        `JSONPath expression '${this.pathExpression}' evaluated to ${quoteJSONValue(
+        `Path expression '${this.pathExpression}' evaluated to ${quoteJSONValue(
           value
         )}, but expected a timestamp conforming to the RFC3339 profile`
       );

--- a/src/stateMachine/jsonPath/constraints/StringConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/StringConstraint.ts
@@ -1,0 +1,12 @@
+import { BaseJSONPathConstraint } from './BaseJsonPathConstraint';
+import { StatesRuntimeError } from '../../../error/predefined/StatesRuntimeError';
+
+export class StringConstraint extends BaseJSONPathConstraint {
+  test(value: unknown): void {
+    if (typeof value !== 'string') {
+      throw new StatesRuntimeError(
+        `JSONPath expression '${this.pathExpression}' evaluated to ${value}, but expected a string`
+      );
+    }
+  }
+}

--- a/src/stateMachine/jsonPath/constraints/StringConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/StringConstraint.ts
@@ -6,7 +6,7 @@ export class StringConstraint extends BaseJSONPathConstraint {
   test(value: unknown): void {
     if (typeof value !== 'string') {
       throw new StatesRuntimeError(
-        `JSONPath expression '${this.pathExpression}' evaluated to ${quoteJSONValue(value)}, but expected a string`
+        `Path expression '${this.pathExpression}' evaluated to ${quoteJSONValue(value)}, but expected a string`
       );
     }
   }

--- a/src/stateMachine/jsonPath/constraints/StringConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/StringConstraint.ts
@@ -1,11 +1,12 @@
 import { BaseJSONPathConstraint } from './BaseJsonPathConstraint';
 import { StatesRuntimeError } from '../../../error/predefined/StatesRuntimeError';
+import { quoteJSONValue } from '../../../util';
 
 export class StringConstraint extends BaseJSONPathConstraint {
   test(value: unknown): void {
     if (typeof value !== 'string') {
       throw new StatesRuntimeError(
-        `JSONPath expression '${this.pathExpression}' evaluated to ${value}, but expected a string`
+        `JSONPath expression '${this.pathExpression}' evaluated to ${quoteJSONValue(value)}, but expected a string`
       );
     }
   }

--- a/src/stateMachine/jsonPath/constraints/StringConstraint.ts
+++ b/src/stateMachine/jsonPath/constraints/StringConstraint.ts
@@ -1,12 +1,12 @@
 import { BaseJSONPathConstraint } from './BaseJsonPathConstraint';
 import { StatesRuntimeError } from '../../../error/predefined/StatesRuntimeError';
-import { quoteJSONValue } from '../../../util';
+import { stringifyJSONValue } from '../../../util';
 
 export class StringConstraint extends BaseJSONPathConstraint {
   test(value: unknown): void {
     if (typeof value !== 'string') {
       throw new StatesRuntimeError(
-        `Path expression '${this.pathExpression}' evaluated to ${quoteJSONValue(value)}, but expected a string`
+        `Path expression '${this.pathExpression}' evaluated to ${stringifyJSONValue(value)}, but expected a string`
       );
     }
   }

--- a/src/stateMachine/stateActions/ChoiceStateAction.ts
+++ b/src/stateMachine/stateActions/ChoiceStateAction.ts
@@ -37,7 +37,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('StringEqualsPath' in choiceRule) {
       const varValue = jsonPathQuery<string>(choiceRule.Variable, input, context);
-      const stringValue = jsonPathQuery<string>(choiceRule.StringEqualsPath, input, context, [StringConstraint]);
+      const stringValue = jsonPathQuery<string>(choiceRule.StringEqualsPath, input, context, {
+        constraints: [StringConstraint],
+      });
       return varValue === stringValue;
     }
 
@@ -48,7 +50,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('StringLessThanPath' in choiceRule) {
       const varValue = jsonPathQuery<string>(choiceRule.Variable, input, context);
-      const stringValue = jsonPathQuery<string>(choiceRule.StringLessThanPath, input, context, [StringConstraint]);
+      const stringValue = jsonPathQuery<string>(choiceRule.StringLessThanPath, input, context, {
+        constraints: [StringConstraint],
+      });
       return varValue < stringValue;
     }
 
@@ -59,7 +63,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('StringGreaterThanPath' in choiceRule) {
       const varValue = jsonPathQuery<string>(choiceRule.Variable, input, context);
-      const stringValue = jsonPathQuery<string>(choiceRule.StringGreaterThanPath, input, context, [StringConstraint]);
+      const stringValue = jsonPathQuery<string>(choiceRule.StringGreaterThanPath, input, context, {
+        constraints: [StringConstraint],
+      });
       return varValue > stringValue;
     }
 
@@ -70,9 +76,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('StringLessThanEqualsPath' in choiceRule) {
       const varValue = jsonPathQuery<string>(choiceRule.Variable, input, context);
-      const stringValue = jsonPathQuery<string>(choiceRule.StringLessThanEqualsPath, input, context, [
-        StringConstraint,
-      ]);
+      const stringValue = jsonPathQuery<string>(choiceRule.StringLessThanEqualsPath, input, context, {
+        constraints: [StringConstraint],
+      });
       return varValue <= stringValue;
     }
 
@@ -83,9 +89,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('StringGreaterThanEqualsPath' in choiceRule) {
       const varValue = jsonPathQuery<string>(choiceRule.Variable, input, context);
-      const stringValue = jsonPathQuery<string>(choiceRule.StringGreaterThanEqualsPath, input, context, [
-        StringConstraint,
-      ]);
+      const stringValue = jsonPathQuery<string>(choiceRule.StringGreaterThanEqualsPath, input, context, {
+        constraints: [StringConstraint],
+      });
       return varValue >= stringValue;
     }
 
@@ -102,7 +108,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('NumericEqualsPath' in choiceRule) {
       const varValue = jsonPathQuery<number>(choiceRule.Variable, input, context);
-      const numberValue = jsonPathQuery<number>(choiceRule.NumericEqualsPath, input, context, [NumberConstraint]);
+      const numberValue = jsonPathQuery<number>(choiceRule.NumericEqualsPath, input, context, {
+        constraints: [NumberConstraint],
+      });
       return varValue === numberValue;
     }
 
@@ -113,7 +121,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('NumericLessThanPath' in choiceRule) {
       const varValue = jsonPathQuery<number>(choiceRule.Variable, input, context);
-      const numberValue = jsonPathQuery<number>(choiceRule.NumericLessThanPath, input, context, [NumberConstraint]);
+      const numberValue = jsonPathQuery<number>(choiceRule.NumericLessThanPath, input, context, {
+        constraints: [NumberConstraint],
+      });
       return varValue < numberValue;
     }
 
@@ -124,7 +134,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('NumericGreaterThanPath' in choiceRule) {
       const varValue = jsonPathQuery<number>(choiceRule.Variable, input, context);
-      const numberValue = jsonPathQuery<number>(choiceRule.NumericGreaterThanPath, input, context, [NumberConstraint]);
+      const numberValue = jsonPathQuery<number>(choiceRule.NumericGreaterThanPath, input, context, {
+        constraints: [NumberConstraint],
+      });
       return varValue > numberValue;
     }
 
@@ -135,9 +147,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('NumericLessThanEqualsPath' in choiceRule) {
       const varValue = jsonPathQuery<number>(choiceRule.Variable, input, context);
-      const numberValue = jsonPathQuery<number>(choiceRule.NumericLessThanEqualsPath, input, context, [
-        NumberConstraint,
-      ]);
+      const numberValue = jsonPathQuery<number>(choiceRule.NumericLessThanEqualsPath, input, context, {
+        constraints: [NumberConstraint],
+      });
       return varValue <= numberValue;
     }
 
@@ -148,9 +160,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('NumericGreaterThanEqualsPath' in choiceRule) {
       const varValue = jsonPathQuery<number>(choiceRule.Variable, input, context);
-      const numberValue = jsonPathQuery<number>(choiceRule.NumericGreaterThanEqualsPath, input, context, [
-        NumberConstraint,
-      ]);
+      const numberValue = jsonPathQuery<number>(choiceRule.NumericGreaterThanEqualsPath, input, context, {
+        constraints: [NumberConstraint],
+      });
       return varValue >= numberValue;
     }
 
@@ -161,7 +173,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('BooleanEqualsPath' in choiceRule) {
       const varValue = jsonPathQuery<boolean>(choiceRule.Variable, input, context);
-      const booleanValue = jsonPathQuery<boolean>(choiceRule.BooleanEqualsPath, input, context, [BooleanConstraint]);
+      const booleanValue = jsonPathQuery<boolean>(choiceRule.BooleanEqualsPath, input, context, {
+        constraints: [BooleanConstraint],
+      });
       return varValue === booleanValue;
     }
 
@@ -174,7 +188,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
     if ('TimestampEqualsPath' in choiceRule) {
       const varValue = new Date(jsonPathQuery<string>(choiceRule.Variable, input, context));
       const timestampValue = new Date(
-        jsonPathQuery<string>(choiceRule.TimestampEqualsPath, input, context, [RFC3339TimestampConstraint])
+        jsonPathQuery<string>(choiceRule.TimestampEqualsPath, input, context, {
+          constraints: [RFC3339TimestampConstraint],
+        })
       );
       return varValue.getTime() === timestampValue.getTime();
     }
@@ -188,7 +204,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
     if ('TimestampLessThanPath' in choiceRule) {
       const varValue = new Date(jsonPathQuery<string>(choiceRule.Variable, input, context));
       const timestampValue = new Date(
-        jsonPathQuery<string>(choiceRule.TimestampLessThanPath, input, context, [RFC3339TimestampConstraint])
+        jsonPathQuery<string>(choiceRule.TimestampLessThanPath, input, context, {
+          constraints: [RFC3339TimestampConstraint],
+        })
       );
       return varValue < timestampValue;
     }
@@ -202,7 +220,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
     if ('TimestampGreaterThanPath' in choiceRule) {
       const varValue = new Date(jsonPathQuery<string>(choiceRule.Variable, input, context));
       const timestampValue = new Date(
-        jsonPathQuery<string>(choiceRule.TimestampGreaterThanPath, input, context, [RFC3339TimestampConstraint])
+        jsonPathQuery<string>(choiceRule.TimestampGreaterThanPath, input, context, {
+          constraints: [RFC3339TimestampConstraint],
+        })
       );
       return varValue > timestampValue;
     }
@@ -216,7 +236,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
     if ('TimestampLessThanEqualsPath' in choiceRule) {
       const varValue = new Date(jsonPathQuery<string>(choiceRule.Variable, input, context));
       const timestampValue = new Date(
-        jsonPathQuery<string>(choiceRule.TimestampLessThanEqualsPath, input, context, [RFC3339TimestampConstraint])
+        jsonPathQuery<string>(choiceRule.TimestampLessThanEqualsPath, input, context, {
+          constraints: [RFC3339TimestampConstraint],
+        })
       );
       return varValue <= timestampValue;
     }
@@ -230,7 +252,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
     if ('TimestampGreaterThanEqualsPath' in choiceRule) {
       const varValue = new Date(jsonPathQuery<string>(choiceRule.Variable, input, context));
       const timestampValue = new Date(
-        jsonPathQuery<string>(choiceRule.TimestampGreaterThanEqualsPath, input, context, [RFC3339TimestampConstraint])
+        jsonPathQuery<string>(choiceRule.TimestampGreaterThanEqualsPath, input, context, {
+          constraints: [RFC3339TimestampConstraint],
+        })
       );
       return varValue >= timestampValue;
     }
@@ -242,7 +266,7 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
     }
 
     if ('IsPresent' in choiceRule) {
-      const varValue = jsonPathQuery(choiceRule.Variable, input, context);
+      const varValue = jsonPathQuery(choiceRule.Variable, input, context, { ignoreDefinedValueConstraint: true });
       const IsPresentTrue = choiceRule.IsPresent;
       return IsPresentTrue && varValue !== undefined;
     }

--- a/src/stateMachine/stateActions/ChoiceStateAction.ts
+++ b/src/stateMachine/stateActions/ChoiceStateAction.ts
@@ -3,7 +3,7 @@ import type { ChoiceState, ChoiceRuleWithoutNext } from '../../typings/ChoiceSta
 import type { ChoiceStateActionOptions, ActionResult } from '../../typings/StateActions';
 import type { Context } from '../../typings/Context';
 import { BaseStateAction } from './BaseStateAction';
-import { jsonPathQuery } from '../JsonPath';
+import { jsonPathQuery } from '../jsonPath/JsonPath';
 import { StatesNoChoiceMatchedError } from '../../error/predefined/StatesNoChoiceMatchedError';
 import wcmatch from 'wildcard-match';
 

--- a/src/stateMachine/stateActions/ChoiceStateAction.ts
+++ b/src/stateMachine/stateActions/ChoiceStateAction.ts
@@ -6,6 +6,10 @@ import { BaseStateAction } from './BaseStateAction';
 import { jsonPathQuery } from '../jsonPath/JsonPath';
 import { StatesNoChoiceMatchedError } from '../../error/predefined/StatesNoChoiceMatchedError';
 import { isRFC3339Date } from '../../util';
+import { StringConstraint } from '../jsonPath/constraints/StringConstraint';
+import { NumberConstraint } from '../jsonPath/constraints/NumberConstraint';
+import { BooleanConstraint } from '../jsonPath/constraints/BooleanConstraint';
+import { RFC3339TimestampConstraint } from '../jsonPath/constraints/RFC3339TimestampConstraint';
 import wcmatch from 'wildcard-match';
 
 class ChoiceStateAction extends BaseStateAction<ChoiceState> {
@@ -33,7 +37,7 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('StringEqualsPath' in choiceRule) {
       const varValue = jsonPathQuery<string>(choiceRule.Variable, input, context);
-      const stringValue = jsonPathQuery<string>(choiceRule.StringEqualsPath, input, context);
+      const stringValue = jsonPathQuery<string>(choiceRule.StringEqualsPath, input, context, [StringConstraint]);
       return varValue === stringValue;
     }
 
@@ -44,7 +48,7 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('StringLessThanPath' in choiceRule) {
       const varValue = jsonPathQuery<string>(choiceRule.Variable, input, context);
-      const stringValue = jsonPathQuery<string>(choiceRule.StringLessThanPath, input, context);
+      const stringValue = jsonPathQuery<string>(choiceRule.StringLessThanPath, input, context, [StringConstraint]);
       return varValue < stringValue;
     }
 
@@ -55,7 +59,7 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('StringGreaterThanPath' in choiceRule) {
       const varValue = jsonPathQuery<string>(choiceRule.Variable, input, context);
-      const stringValue = jsonPathQuery<string>(choiceRule.StringGreaterThanPath, input, context);
+      const stringValue = jsonPathQuery<string>(choiceRule.StringGreaterThanPath, input, context, [StringConstraint]);
       return varValue > stringValue;
     }
 
@@ -66,7 +70,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('StringLessThanEqualsPath' in choiceRule) {
       const varValue = jsonPathQuery<string>(choiceRule.Variable, input, context);
-      const stringValue = jsonPathQuery<string>(choiceRule.StringLessThanEqualsPath, input, context);
+      const stringValue = jsonPathQuery<string>(choiceRule.StringLessThanEqualsPath, input, context, [
+        StringConstraint,
+      ]);
       return varValue <= stringValue;
     }
 
@@ -77,7 +83,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('StringGreaterThanEqualsPath' in choiceRule) {
       const varValue = jsonPathQuery<string>(choiceRule.Variable, input, context);
-      const stringValue = jsonPathQuery<string>(choiceRule.StringGreaterThanEqualsPath, input, context);
+      const stringValue = jsonPathQuery<string>(choiceRule.StringGreaterThanEqualsPath, input, context, [
+        StringConstraint,
+      ]);
       return varValue >= stringValue;
     }
 
@@ -94,7 +102,7 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('NumericEqualsPath' in choiceRule) {
       const varValue = jsonPathQuery<number>(choiceRule.Variable, input, context);
-      const numberValue = jsonPathQuery<number>(choiceRule.NumericEqualsPath, input, context);
+      const numberValue = jsonPathQuery<number>(choiceRule.NumericEqualsPath, input, context, [NumberConstraint]);
       return varValue === numberValue;
     }
 
@@ -105,7 +113,7 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('NumericLessThanPath' in choiceRule) {
       const varValue = jsonPathQuery<number>(choiceRule.Variable, input, context);
-      const numberValue = jsonPathQuery<number>(choiceRule.NumericLessThanPath, input, context);
+      const numberValue = jsonPathQuery<number>(choiceRule.NumericLessThanPath, input, context, [NumberConstraint]);
       return varValue < numberValue;
     }
 
@@ -116,7 +124,7 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('NumericGreaterThanPath' in choiceRule) {
       const varValue = jsonPathQuery<number>(choiceRule.Variable, input, context);
-      const numberValue = jsonPathQuery<number>(choiceRule.NumericGreaterThanPath, input, context);
+      const numberValue = jsonPathQuery<number>(choiceRule.NumericGreaterThanPath, input, context, [NumberConstraint]);
       return varValue > numberValue;
     }
 
@@ -127,7 +135,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('NumericLessThanEqualsPath' in choiceRule) {
       const varValue = jsonPathQuery<number>(choiceRule.Variable, input, context);
-      const numberValue = jsonPathQuery<number>(choiceRule.NumericLessThanEqualsPath, input, context);
+      const numberValue = jsonPathQuery<number>(choiceRule.NumericLessThanEqualsPath, input, context, [
+        NumberConstraint,
+      ]);
       return varValue <= numberValue;
     }
 
@@ -138,7 +148,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('NumericGreaterThanEqualsPath' in choiceRule) {
       const varValue = jsonPathQuery<number>(choiceRule.Variable, input, context);
-      const numberValue = jsonPathQuery<number>(choiceRule.NumericGreaterThanEqualsPath, input, context);
+      const numberValue = jsonPathQuery<number>(choiceRule.NumericGreaterThanEqualsPath, input, context, [
+        NumberConstraint,
+      ]);
       return varValue >= numberValue;
     }
 
@@ -149,7 +161,7 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('BooleanEqualsPath' in choiceRule) {
       const varValue = jsonPathQuery<boolean>(choiceRule.Variable, input, context);
-      const booleanValue = jsonPathQuery<boolean>(choiceRule.BooleanEqualsPath, input, context);
+      const booleanValue = jsonPathQuery<boolean>(choiceRule.BooleanEqualsPath, input, context, [BooleanConstraint]);
       return varValue === booleanValue;
     }
 
@@ -161,7 +173,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('TimestampEqualsPath' in choiceRule) {
       const varValue = new Date(jsonPathQuery<string>(choiceRule.Variable, input, context));
-      const timestampValue = new Date(jsonPathQuery<string>(choiceRule.TimestampEqualsPath, input, context));
+      const timestampValue = new Date(
+        jsonPathQuery<string>(choiceRule.TimestampEqualsPath, input, context, [RFC3339TimestampConstraint])
+      );
       return varValue.getTime() === timestampValue.getTime();
     }
 
@@ -173,7 +187,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('TimestampLessThanPath' in choiceRule) {
       const varValue = new Date(jsonPathQuery<string>(choiceRule.Variable, input, context));
-      const timestampValue = new Date(jsonPathQuery<string>(choiceRule.TimestampLessThanPath, input, context));
+      const timestampValue = new Date(
+        jsonPathQuery<string>(choiceRule.TimestampLessThanPath, input, context, [RFC3339TimestampConstraint])
+      );
       return varValue < timestampValue;
     }
 
@@ -185,7 +201,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('TimestampGreaterThanPath' in choiceRule) {
       const varValue = new Date(jsonPathQuery<string>(choiceRule.Variable, input, context));
-      const timestampValue = new Date(jsonPathQuery<string>(choiceRule.TimestampGreaterThanPath, input, context));
+      const timestampValue = new Date(
+        jsonPathQuery<string>(choiceRule.TimestampGreaterThanPath, input, context, [RFC3339TimestampConstraint])
+      );
       return varValue > timestampValue;
     }
 
@@ -197,7 +215,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('TimestampLessThanEqualsPath' in choiceRule) {
       const varValue = new Date(jsonPathQuery<string>(choiceRule.Variable, input, context));
-      const timestampValue = new Date(jsonPathQuery<string>(choiceRule.TimestampLessThanEqualsPath, input, context));
+      const timestampValue = new Date(
+        jsonPathQuery<string>(choiceRule.TimestampLessThanEqualsPath, input, context, [RFC3339TimestampConstraint])
+      );
       return varValue <= timestampValue;
     }
 
@@ -209,7 +229,9 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
 
     if ('TimestampGreaterThanEqualsPath' in choiceRule) {
       const varValue = new Date(jsonPathQuery<string>(choiceRule.Variable, input, context));
-      const timestampValue = new Date(jsonPathQuery<string>(choiceRule.TimestampGreaterThanEqualsPath, input, context));
+      const timestampValue = new Date(
+        jsonPathQuery<string>(choiceRule.TimestampGreaterThanEqualsPath, input, context, [RFC3339TimestampConstraint])
+      );
       return varValue >= timestampValue;
     }
 

--- a/src/stateMachine/stateActions/ChoiceStateAction.ts
+++ b/src/stateMachine/stateActions/ChoiceStateAction.ts
@@ -5,6 +5,7 @@ import type { Context } from '../../typings/Context';
 import { BaseStateAction } from './BaseStateAction';
 import { jsonPathQuery } from '../jsonPath/JsonPath';
 import { StatesNoChoiceMatchedError } from '../../error/predefined/StatesNoChoiceMatchedError';
+import { isRFC3339Date } from '../../util';
 import wcmatch from 'wildcard-match';
 
 class ChoiceStateAction extends BaseStateAction<ChoiceState> {
@@ -245,7 +246,7 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
     if ('IsTimestamp' in choiceRule) {
       const varValue = jsonPathQuery<string>(choiceRule.Variable, input, context);
       const IsTimestampTrue = choiceRule.IsTimestamp;
-      return IsTimestampTrue && /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(Z|(\+|-)\d{2}:\d{2})/.test(varValue);
+      return IsTimestampTrue && isRFC3339Date(varValue);
     }
 
     return false;

--- a/src/stateMachine/stateActions/ChoiceStateAction.ts
+++ b/src/stateMachine/stateActions/ChoiceStateAction.ts
@@ -5,7 +5,7 @@ import type { Context } from '../../typings/Context';
 import { BaseStateAction } from './BaseStateAction';
 import { jsonPathQuery } from '../jsonPath/JsonPath';
 import { StatesNoChoiceMatchedError } from '../../error/predefined/StatesNoChoiceMatchedError';
-import { isRFC3339Date } from '../../util';
+import { isRFC3339Timestamp } from '../../util';
 import { StringConstraint } from '../jsonPath/constraints/StringConstraint';
 import { NumberConstraint } from '../jsonPath/constraints/NumberConstraint';
 import { BooleanConstraint } from '../jsonPath/constraints/BooleanConstraint';
@@ -292,7 +292,7 @@ class ChoiceStateAction extends BaseStateAction<ChoiceState> {
     if ('IsTimestamp' in choiceRule) {
       const varValue = jsonPathQuery<string>(choiceRule.Variable, input, context);
       const IsTimestampTrue = choiceRule.IsTimestamp;
-      return IsTimestampTrue && isRFC3339Date(varValue);
+      return IsTimestampTrue && isRFC3339Timestamp(varValue);
     }
 
     return false;

--- a/src/stateMachine/stateActions/MapStateAction.ts
+++ b/src/stateMachine/stateActions/MapStateAction.ts
@@ -10,6 +10,7 @@ import { jsonPathQuery } from '../jsonPath/JsonPath';
 import { processPayloadTemplate } from '../InputOutputProcessing';
 import { StatesRuntimeError } from '../../error/predefined/StatesRuntimeError';
 import { ExecutionError } from '../../error/ExecutionError';
+import { ArrayConstraint } from '../jsonPath/constraints/ArrayConstraint';
 import pLimit from 'p-limit';
 
 /**
@@ -77,7 +78,7 @@ class MapStateAction extends BaseStateAction<MapState> {
 
     let items = input;
     if (state.ItemsPath) {
-      items = jsonPathQuery(state.ItemsPath, input, context);
+      items = jsonPathQuery(state.ItemsPath, input, context, [ArrayConstraint]);
     }
 
     if (!Array.isArray(items)) {

--- a/src/stateMachine/stateActions/MapStateAction.ts
+++ b/src/stateMachine/stateActions/MapStateAction.ts
@@ -78,7 +78,9 @@ class MapStateAction extends BaseStateAction<MapState> {
 
     let items = input;
     if (state.ItemsPath) {
-      items = jsonPathQuery(state.ItemsPath, input, context, [ArrayConstraint]);
+      items = jsonPathQuery(state.ItemsPath, input, context, {
+        constraints: [ArrayConstraint],
+      });
     }
 
     if (!Array.isArray(items)) {

--- a/src/stateMachine/stateActions/MapStateAction.ts
+++ b/src/stateMachine/stateActions/MapStateAction.ts
@@ -6,7 +6,7 @@ import type { EventLogger } from '../EventLogger';
 import type { EventLog } from '../../typings/EventLogs';
 import { BaseStateAction } from './BaseStateAction';
 import { StateMachine } from '../StateMachine';
-import { jsonPathQuery } from '../JsonPath';
+import { jsonPathQuery } from '../jsonPath/JsonPath';
 import { processPayloadTemplate } from '../InputOutputProcessing';
 import { StatesRuntimeError } from '../../error/predefined/StatesRuntimeError';
 import { ExecutionError } from '../../error/ExecutionError';

--- a/src/stateMachine/stateActions/WaitStateAction.ts
+++ b/src/stateMachine/stateActions/WaitStateAction.ts
@@ -3,7 +3,7 @@ import type { WaitState } from '../../typings/WaitState';
 import type { ActionResult, WaitStateActionOptions } from '../../typings/StateActions';
 import type { Context } from '../../typings/Context';
 import { BaseStateAction } from './BaseStateAction';
-import { jsonPathQuery } from '../JsonPath';
+import { jsonPathQuery } from '../jsonPath/JsonPath';
 import { sleep } from '../../util';
 
 class WaitStateAction extends BaseStateAction<WaitState> {

--- a/src/stateMachine/stateActions/WaitStateAction.ts
+++ b/src/stateMachine/stateActions/WaitStateAction.ts
@@ -4,6 +4,8 @@ import type { ActionResult, WaitStateActionOptions } from '../../typings/StateAc
 import type { Context } from '../../typings/Context';
 import { BaseStateAction } from './BaseStateAction';
 import { jsonPathQuery } from '../jsonPath/JsonPath';
+import { IntegerConstraint } from '../jsonPath/constraints/IntegerConstraint';
+import { RFC3339TimestampConstraint } from '../jsonPath/constraints/RFC3339TimestampConstraint';
 import { sleep } from '../../util';
 
 class WaitStateAction extends BaseStateAction<WaitState> {
@@ -29,10 +31,12 @@ class WaitStateAction extends BaseStateAction<WaitState> {
 
       await sleep(timeDiff, options.abortSignal, options.rootAbortSignal);
     } else if (state.SecondsPath) {
-      const seconds = jsonPathQuery<number>(state.SecondsPath, input, context);
+      const seconds = jsonPathQuery<number>(state.SecondsPath, input, context, [
+        IntegerConstraint.greaterThanOrEqual(0),
+      ]);
       await sleep(seconds * 1000, options.abortSignal, options.rootAbortSignal);
     } else if (state.TimestampPath) {
-      const timestamp = jsonPathQuery<string>(state.TimestampPath, input, context);
+      const timestamp = jsonPathQuery<string>(state.TimestampPath, input, context, [RFC3339TimestampConstraint]);
       const dateTimestamp = new Date(timestamp);
       const currentTime = Date.now();
       const timeDiff = dateTimestamp.getTime() - currentTime;

--- a/src/stateMachine/stateActions/WaitStateAction.ts
+++ b/src/stateMachine/stateActions/WaitStateAction.ts
@@ -31,12 +31,14 @@ class WaitStateAction extends BaseStateAction<WaitState> {
 
       await sleep(timeDiff, options.abortSignal, options.rootAbortSignal);
     } else if (state.SecondsPath) {
-      const seconds = jsonPathQuery<number>(state.SecondsPath, input, context, [
-        IntegerConstraint.greaterThanOrEqual(0),
-      ]);
+      const seconds = jsonPathQuery<number>(state.SecondsPath, input, context, {
+        constraints: [IntegerConstraint.greaterThanOrEqual(0)],
+      });
       await sleep(seconds * 1000, options.abortSignal, options.rootAbortSignal);
     } else if (state.TimestampPath) {
-      const timestamp = jsonPathQuery<string>(state.TimestampPath, input, context, [RFC3339TimestampConstraint]);
+      const timestamp = jsonPathQuery<string>(state.TimestampPath, input, context, {
+        constraints: [RFC3339TimestampConstraint],
+      });
       const dateTimestamp = new Date(timestamp);
       const currentTime = Date.now();
       const timeDiff = dateTimestamp.getTime() - currentTime;

--- a/src/typings/JSONPathImplementation.ts
+++ b/src/typings/JSONPathImplementation.ts
@@ -1,0 +1,6 @@
+import type { BaseJSONPathConstraint } from '../stateMachine/jsonPath/constraints/BaseJsonPathConstraint';
+
+export interface JSONPathQueryOptions {
+  constraints?: (new (...params: ConstructorParameters<typeof BaseJSONPathConstraint>) => BaseJSONPathConstraint)[];
+  ignoreDefinedValueConstraint?: boolean;
+}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -76,7 +76,7 @@ export function isRFC3339Date(date: string): boolean {
   return regex.test(date);
 }
 
-export function quoteJSONValue(value: unknown) {
+export function stringifyJSONValue(value: unknown) {
   return JSON.stringify(value);
 }
 

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -69,7 +69,7 @@ export function tryJSONParse<T>(jsonStr: string): T | Error {
   }
 }
 
-export function isRFC3339Date(date: string): boolean {
+export function isRFC3339Timestamp(date: string): boolean {
   const regex =
     /^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])(\.\d+)?(Z|(\+|-)([01][0-9]|2[0-3]):([0-5][0-9]))$/;
 

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -69,4 +69,11 @@ export function tryJSONParse<T>(jsonStr: string): T | Error {
   }
 }
 
+export function isRFC3339Date(date: string): boolean {
+  const regex =
+    /^\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])T([01][0-9]|2[0-3]):([0-5][0-9]):([0-5][0-9])(\.\d+)?(Z|(\+|-)([01][0-9]|2[0-3]):([0-5][0-9]))$/;
+
+  return regex.test(date);
+}
+
 export { getRandomNumber, sfc32, cyrb128 } from './random';

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -76,4 +76,8 @@ export function isRFC3339Date(date: string): boolean {
   return regex.test(date);
 }
 
+export function quoteJSONValue(value: unknown) {
+  return JSON.stringify(value);
+}
+
 export { getRandomNumber, sfc32, cyrb128 } from './random';


### PR DESCRIPTION
Adds validations to verify if the result of a JSONPath evaluation fulfills with certain constraints. Otherwise a `States.Runtime` error is thrown and the state machine fails. 