### PR TITLE
Feature/no validate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,8 @@ The constructor takes the following parameters:
   - `validationOptions?`: An object that specifies how the definition should be validated.
     - `checkPaths`: If set to `false`, won't validate JSONPaths.
     - `checkArn`: If set to `false`, won't validate ARN syntax in `Task` states.
+    - `noValidate`: If set to `true`, will skip validation of the definition entirely.
+      > NOTE: Use this option at your own risk, there are no guarantees when passing an invalid/non-standard definition to the state machine. Running it might result in undefined behavior.
   - `awsConfig?`: An object that specifies the [AWS region and credentials](/docs/feature-support.md#providing-aws-credentials-and-region-to-execute-lambda-functions-specified-in-task-states) to use when invoking a Lambda function in a `Task` state. If not set, the AWS config will be resolved based on the [credentials provider chain](https://docs.aws.amazon.com/sdk-for-javascript/v3/developer-guide/setting-credentials-node.html) of the AWS SDK for JavaScript V3. You don't need to use this option if you have a [shared config/credentials file](https://docs.aws.amazon.com/sdkref/latest/guide/file-format.html) (for example, if you have the [AWS CLI](https://aws.amazon.com/cli/) installed) or if you use a local override for all of your `Task` states.
     - `region`: The AWS region where the Lambda functions are created.
     - `credentials`: An object that specifies which type of credentials to use.

--- a/__tests__/StateMachine.test.ts
+++ b/__tests__/StateMachine.test.ts
@@ -84,6 +84,31 @@ describe('State Machine', () => {
         new StateMachine(stateMachineDefinition, stateMachineOptions);
       }).not.toThrow();
     });
+
+    test('should not throw if definition validation is completely turned off when creating instance', async () => {
+      const stateMachineDefinition: StateMachineDefinition = {
+        StartAt: 'FirstState',
+        States: {
+          FirstState: {
+            Type: 'Pass',
+            InputPath: 'invalidPath',
+            ResultPath: 'invalidPath',
+            OutputPath: 'invalidPath',
+            End: true,
+          },
+          UnreachableState: {
+            // @ts-expect-error Invalid state type
+            Type: 'InvalidType',
+          },
+        },
+        InvalidTopLevelField: {},
+      };
+      const stateMachineOptions = { validationOptions: { noValidate: true } };
+
+      expect(() => {
+        new StateMachine(stateMachineDefinition, stateMachineOptions);
+      }).not.toThrow();
+    });
   });
 
   describe('run()', () => {

--- a/examples/README.md
+++ b/examples/README.md
@@ -9,7 +9,9 @@ Here you can find some useful examples demonstrating specific usages of AWS Loca
 - [check-for-execution-failure](./check-for-execution-failure.js): Check if execution failed and catch error.
 - [check-for-execution-timeout](./check-for-execution-timeout.js): Check if execution timed out because the execution ran longer than the seconds specified in the `TimeoutSeconds` field and catch error.
 - [custom-context-object](./custom-context-object.js): Pass a mock Context Object to the execution.
-- [disable-state-machine-validation](./disable-state-machine-validation.js): Disable ARN and/or JSONPath validations when instantiating a new `StateMachine` object.
+- [disable-arn-validation](./disable-arn-validation.js): Disable ARN validation when instantiating a new `StateMachine` object.
+- [disable-jsonpath-validation](./disable-jsonpath-validation.js): Disable JSONPath validation when instantiating a new `StateMachine` object.
+- [disable-state-machine-validation](./disable-state-machine-validation.js): Completely disable validation of the state machine definition when instantiating a new `StateMachine` object.
 - [execution-event-logs](./execution-event-logs.js): Pulling the log of events produced by an execution as it runs and printing them.
 - [task-state-local-override](./task-state-local-override.js): Override the default action for a `Task` state, so that instead of invoking the Lambda specified in the `Resource` field, it runs a local function. This allows running state machines completely locally.
 - [wait-state-local-override](./wait-state-local-override.js): Override the wait duration of a `Wait` state so that instead of waiting the duration specified in the `Seconds`, `Timestamp`, `SecondsPath`, `TimestampPath` fields, it waits for a specified number of milliseconds.

--- a/examples/disable-arn-validation.js
+++ b/examples/disable-arn-validation.js
@@ -6,23 +6,17 @@ const machineDefinition = {
   States: {
     'Hello World': {
       Type: 'Task',
-      Resource: 'arn:aws:lambda:us-east-1:123456789012:function:AddNumbers',
+      InputPath: '$.data',
+      Resource: 'invalid arn syntax',
       End: true,
     },
-    UnreachableState: {
-      Type: 'Succeed',
-    },
-    InvalidStateType: {
-      Type: 'SomeNewType',
-    },
   },
-  InvalidTopLevelField: {},
 };
 
-// Construct a new state machine with the given definition and don't validate it at all
+// Construct a new state machine with the given definition and don't validate ARNs
 const stateMachine = new StateMachine(machineDefinition, {
   validationOptions: {
-    noValidate: true,
+    checkArn: false,
   },
 });
 

--- a/examples/disable-jsonpath-validation.js
+++ b/examples/disable-jsonpath-validation.js
@@ -6,23 +6,17 @@ const machineDefinition = {
   States: {
     'Hello World': {
       Type: 'Task',
+      InputPath: 'invalid JSONPath syntax',
       Resource: 'arn:aws:lambda:us-east-1:123456789012:function:AddNumbers',
       End: true,
     },
-    UnreachableState: {
-      Type: 'Succeed',
-    },
-    InvalidStateType: {
-      Type: 'SomeNewType',
-    },
   },
-  InvalidTopLevelField: {},
 };
 
-// Construct a new state machine with the given definition and don't validate it at all
+// Construct a new state machine with the given definition and don't validate JSONPaths
 const stateMachine = new StateMachine(machineDefinition, {
   validationOptions: {
-    noValidate: true,
+    checkPaths: false,
   },
 });
 

--- a/src/stateMachine/StateMachine.ts
+++ b/src/stateMachine/StateMachine.ts
@@ -29,7 +29,7 @@ export class StateMachine {
    * These options also apply to state machines defined in the `Iterator` field of `Map` states and in the `Branches` field of `Parallel` states.
    */
   constructor(definition: StateMachineDefinition, stateMachineOptions?: StateMachineOptions) {
-    if (!stateMachineOptions?.validationOptions?._noValidate) {
+    if (!stateMachineOptions?.validationOptions?.noValidate) {
       const { isValid, errorsText } = aslValidator(definition, {
         checkArn: true,
         checkPaths: true,

--- a/src/stateMachine/stateActions/MapStateAction.ts
+++ b/src/stateMachine/stateActions/MapStateAction.ts
@@ -89,7 +89,7 @@ class MapStateAction extends BaseStateAction<MapState> {
 
     const iteratorStateMachine = new StateMachine(state.Iterator, {
       ...options.stateMachineOptions,
-      validationOptions: { _noValidate: true },
+      validationOptions: { noValidate: true },
     });
     const limit = pLimit(state.MaxConcurrency || DEFAULT_MAX_CONCURRENCY);
     const processedItemsPromise = items.map((item, i) =>

--- a/src/stateMachine/stateActions/ParallelStateAction.ts
+++ b/src/stateMachine/stateActions/ParallelStateAction.ts
@@ -43,7 +43,7 @@ class ParallelStateAction extends BaseStateAction<ParallelState> {
   ): Promise<JSONValue> {
     const stateMachine = new StateMachine(branch, {
       ...options.stateMachineOptions,
-      validationOptions: { _noValidate: true },
+      validationOptions: { noValidate: true },
     });
     const execution = stateMachine.run(input, options.runOptions);
 

--- a/src/typings/StateMachineImplementation.ts
+++ b/src/typings/StateMachineImplementation.ts
@@ -18,15 +18,9 @@ interface Overrides {
 }
 
 export interface ValidationOptions {
+  readonly noValidate?: boolean;
   readonly checkPaths?: boolean;
   readonly checkArn?: boolean;
-  /**
-   * @internal DO NOT USE.
-   *
-   * This property is meant for internal use only.
-   * There are no guarantees regarding future changes made to this property.
-   */
-  readonly _noValidate?: boolean;
 }
 
 export interface AWSConfig {


### PR DESCRIPTION
- Adds new `noValidate` option for `StateMachine` constructor. When enabled, validation of the state machine definition is completely turned off. 