### PR TITLE
Feature/Fail state ErrorPath CausePath

### DIFF
--- a/__tests__/stateActions/FailStateAction.test.ts
+++ b/__tests__/stateActions/FailStateAction.test.ts
@@ -25,6 +25,28 @@ describe('Fail State', () => {
     await expect(failStateResult).rejects.toThrow('Execution failed because of a Fail state');
   });
 
+  test('should throw `FailStateError` with `Error` value as the error name', async () => {
+    const definition: FailState = {
+      Type: 'Fail',
+      Error: 'Failure',
+    };
+    const stateName = 'FailState';
+    const input = {
+      prop1: 'test',
+      prop2: 12345,
+    };
+    const context = {};
+
+    const failStateAction = new FailStateAction(definition, stateName);
+    try {
+      await failStateAction.execute(input, context);
+    } catch (e) {
+      const error = e as Error;
+      expect(error).toBeInstanceOf(FailStateError);
+      expect(error.name).toBe('Failure');
+    }
+  });
+
   test('should throw `FailStateError` with `Cause` value as error message', async () => {
     const definition: FailState = {
       Type: 'Fail',
@@ -39,9 +61,59 @@ describe('Fail State', () => {
     const context = {};
 
     const failStateAction = new FailStateAction(definition, stateName);
-    const failStateResult = failStateAction.execute(input, context);
+    try {
+      await failStateAction.execute(input, context);
+    } catch (e) {
+      const error = e as Error;
+      expect(error).toBeInstanceOf(FailStateError);
+      expect(error.message).toBe('This is the cause of the error');
+    }
+  });
 
-    await expect(failStateResult).rejects.toThrow(FailStateError);
-    await expect(failStateResult).rejects.toThrow('This is the cause of the error');
+  test('should throw `FailStateError` with value specified in `ErrorPath` field as the error name', async () => {
+    const definition: FailState = {
+      Type: 'Fail',
+      ErrorPath: '$.error.name',
+    };
+    const stateName = 'FailState';
+    const input = {
+      prop1: 'test',
+      prop2: 12345,
+      error: { name: 'Failure' },
+    };
+    const context = {};
+
+    const failStateAction = new FailStateAction(definition, stateName);
+    try {
+      await failStateAction.execute(input, context);
+    } catch (e) {
+      const error = e as Error;
+      expect(error).toBeInstanceOf(FailStateError);
+      expect(error.name).toBe('Failure');
+    }
+  });
+
+  test('should throw `FailStateError` with value specified in `CausePath` field as error message', async () => {
+    const definition: FailState = {
+      Type: 'Fail',
+      Error: 'Failure',
+      CausePath: '$.cause.of.error',
+    };
+    const stateName = 'FailState';
+    const input = {
+      prop1: 'test',
+      prop2: 12345,
+      cause: { of: { error: 'This is the cause of the error' } },
+    };
+    const context = {};
+
+    const failStateAction = new FailStateAction(definition, stateName);
+    try {
+      await failStateAction.execute(input, context);
+    } catch (e) {
+      const error = e as Error;
+      expect(error).toBeInstanceOf(FailStateError);
+      expect(error.message).toBe('This is the cause of the error');
+    }
   });
 });

--- a/src/stateMachine/stateActions/FailStateAction.ts
+++ b/src/stateMachine/stateActions/FailStateAction.ts
@@ -4,6 +4,8 @@ import type { ActionResult, FailStateActionOptions } from '../../typings/StateAc
 import type { Context } from '../../typings/Context';
 import { BaseStateAction } from './BaseStateAction';
 import { FailStateError } from '../../error/FailStateError';
+import { jsonPathQuery } from '../jsonPath/JsonPath';
+import { StringConstraint } from '../jsonPath/constraints/StringConstraint';
 
 class FailStateAction extends BaseStateAction<FailState> {
   constructor(stateDefinition: FailState, stateName: string) {
@@ -18,7 +20,23 @@ class FailStateAction extends BaseStateAction<FailState> {
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     options?: FailStateActionOptions
   ): Promise<ActionResult> {
-    throw new FailStateError(this.stateDefinition.Error, this.stateDefinition.Cause);
+    const state = this.stateDefinition;
+
+    let error = state.Error;
+    let cause = state.Cause;
+
+    if (state.ErrorPath) {
+      error = jsonPathQuery<string>(state.ErrorPath, input, context, {
+        constraints: [StringConstraint],
+      });
+    }
+    if (state.CausePath) {
+      cause = jsonPathQuery<string>(state.CausePath, input, context, {
+        constraints: [StringConstraint],
+      });
+    }
+
+    throw new FailStateError(error, cause);
   }
 }
 

--- a/src/typings/FailState.ts
+++ b/src/typings/FailState.ts
@@ -4,7 +4,9 @@ import type { TerminalState } from './TerminalState';
 interface BaseFailState extends BaseState {
   Type: 'Fail';
   Cause?: string;
+  CausePath?: string;
   Error?: string;
+  ErrorPath?: string;
 }
 
 export type FailState = TerminalState & BaseFailState;


### PR DESCRIPTION
- Adds support for `ErrorPath` and `CausePath` fields of `Fail` state.

---

Closes #67 