### PR TITLE
Feature/payload template top level array

### DIFF
--- a/__tests__/InputOutputProcessing.test.ts
+++ b/__tests__/InputOutputProcessing.test.ts
@@ -1,3 +1,4 @@
+import type { JSONValue } from '../src/typings/JSONValue';
 import { StatesResultPathMatchFailureError } from '../src/error/predefined/StatesResultPathMatchFailureError';
 import {
   processInputPath,
@@ -268,6 +269,131 @@ describe('Input processing', () => {
       });
     });
 
+    test('should return `Parameters` array payload with values replaced according to path fields', () => {
+      const parameters: JSONValue = [
+        { field1: 50, 'field2.$': '$.movies[0].director' },
+        {
+          field3: false,
+          field4: {
+            'field5.$': '$.metadata',
+            field6: [1, 2, 3],
+          },
+        },
+      ];
+
+      const input = {
+        movies: [
+          {
+            director: 'Quentin Tarantino',
+            title: 'Reservoir Dogs',
+            year: 1992,
+          },
+          {
+            director: 'Brian De Palma',
+            title: 'Mission: Impossible',
+            year: 1996,
+          },
+        ],
+        metadata: {
+          lastUpdated: '2020-05-27T08:00:00Z',
+        },
+      };
+      const context = {};
+
+      const result = processPayloadTemplate(parameters, input, context);
+
+      expect(result).toEqual([
+        { field1: 50, field2: 'Quentin Tarantino' },
+        {
+          field3: false,
+          field4: {
+            field5: {
+              lastUpdated: '2020-05-27T08:00:00Z',
+            },
+            field6: [1, 2, 3],
+          },
+        },
+      ]);
+    });
+
+    test('should return `Parameters` numeric payload as is', () => {
+      const parameters = 3.141592;
+      const input = {
+        movies: [
+          {
+            director: 'Quentin Tarantino',
+            title: 'Reservoir Dogs',
+            year: 1992,
+          },
+          {
+            director: 'Brian De Palma',
+            title: 'Mission: Impossible',
+            year: 1996,
+          },
+        ],
+        metadata: {
+          lastUpdated: '2020-05-27T08:00:00Z',
+        },
+      };
+      const context = {};
+
+      const result = processPayloadTemplate(parameters, input, context);
+
+      expect(result).toEqual(3.141592);
+    });
+
+    test('should return `Parameters` string payload as is', () => {
+      const parameters = 'Hello, world!';
+      const input = {
+        movies: [
+          {
+            director: 'Quentin Tarantino',
+            title: 'Reservoir Dogs',
+            year: 1992,
+          },
+          {
+            director: 'Brian De Palma',
+            title: 'Mission: Impossible',
+            year: 1996,
+          },
+        ],
+        metadata: {
+          lastUpdated: '2020-05-27T08:00:00Z',
+        },
+      };
+      const context = {};
+
+      const result = processPayloadTemplate(parameters, input, context);
+
+      expect(result).toEqual('Hello, world!');
+    });
+
+    test('should return `Parameters` boolean payload as is', () => {
+      const parameters = true;
+      const input = {
+        movies: [
+          {
+            director: 'Quentin Tarantino',
+            title: 'Reservoir Dogs',
+            year: 1992,
+          },
+          {
+            director: 'Brian De Palma',
+            title: 'Mission: Impossible',
+            year: 1996,
+          },
+        ],
+        metadata: {
+          lastUpdated: '2020-05-27T08:00:00Z',
+        },
+      };
+      const context = {};
+
+      const result = processPayloadTemplate(parameters, input, context);
+
+      expect(result).toEqual(true);
+    });
+
     // TODO: Add test to assert field value is valid JSONPath when field name ends with `.$` suffix.
     // For instance: { 'path.$': 'movies' } would not be a valid JSONPath, as the value doesn't begin with `$.`
   });
@@ -441,6 +567,131 @@ describe('Output processing', () => {
           field6: [1, 2, 3],
         },
       });
+    });
+
+    test('should return `ResultSelector` array payload with values replaced according to path fields', () => {
+      const parameters: JSONValue = [
+        { field1: 50, 'field2.$': '$.movies[0].director' },
+        {
+          field3: false,
+          field4: {
+            'field5.$': '$.metadata',
+            field6: [1, 2, 3],
+          },
+        },
+      ];
+
+      const input = {
+        movies: [
+          {
+            director: 'Quentin Tarantino',
+            title: 'Reservoir Dogs',
+            year: 1992,
+          },
+          {
+            director: 'Brian De Palma',
+            title: 'Mission: Impossible',
+            year: 1996,
+          },
+        ],
+        metadata: {
+          lastUpdated: '2020-05-27T08:00:00Z',
+        },
+      };
+      const context = {};
+
+      const result = processPayloadTemplate(parameters, input, context);
+
+      expect(result).toEqual([
+        { field1: 50, field2: 'Quentin Tarantino' },
+        {
+          field3: false,
+          field4: {
+            field5: {
+              lastUpdated: '2020-05-27T08:00:00Z',
+            },
+            field6: [1, 2, 3],
+          },
+        },
+      ]);
+    });
+
+    test('should return `ResultSelector` numeric payload as is', () => {
+      const parameters = 3.141592;
+      const input = {
+        movies: [
+          {
+            director: 'Quentin Tarantino',
+            title: 'Reservoir Dogs',
+            year: 1992,
+          },
+          {
+            director: 'Brian De Palma',
+            title: 'Mission: Impossible',
+            year: 1996,
+          },
+        ],
+        metadata: {
+          lastUpdated: '2020-05-27T08:00:00Z',
+        },
+      };
+      const context = {};
+
+      const result = processPayloadTemplate(parameters, input, context);
+
+      expect(result).toEqual(3.141592);
+    });
+
+    test('should return `ResultSelector` string payload as is', () => {
+      const parameters = 'Hello, world!';
+      const input = {
+        movies: [
+          {
+            director: 'Quentin Tarantino',
+            title: 'Reservoir Dogs',
+            year: 1992,
+          },
+          {
+            director: 'Brian De Palma',
+            title: 'Mission: Impossible',
+            year: 1996,
+          },
+        ],
+        metadata: {
+          lastUpdated: '2020-05-27T08:00:00Z',
+        },
+      };
+      const context = {};
+
+      const result = processPayloadTemplate(parameters, input, context);
+
+      expect(result).toEqual('Hello, world!');
+    });
+
+    test('should return `ResultSelector` boolean payload as is', () => {
+      const parameters = true;
+      const input = {
+        movies: [
+          {
+            director: 'Quentin Tarantino',
+            title: 'Reservoir Dogs',
+            year: 1992,
+          },
+          {
+            director: 'Brian De Palma',
+            title: 'Mission: Impossible',
+            year: 1996,
+          },
+        ],
+        metadata: {
+          lastUpdated: '2020-05-27T08:00:00Z',
+        },
+      };
+      const context = {};
+
+      const result = processPayloadTemplate(parameters, input, context);
+
+      expect(result).toEqual(true);
     });
 
     // TODO: Add test to assert field value is valid JSONPath when field name ends with `.$` suffix.

--- a/src/stateMachine/InputOutputProcessing.ts
+++ b/src/stateMachine/InputOutputProcessing.ts
@@ -48,6 +48,11 @@ function processPayloadTemplate(payloadTemplate: JSONValue, json: JSONValue, con
     let sanitizedKey = key;
     let resolvedValue = value;
 
+    // Recursively process child array
+    if (Array.isArray(value)) {
+      resolvedValue = value.map((innerValue) => processPayloadTemplate(innerValue, json, context));
+    }
+
     // Recursively process child object
     if (isPlainObj(value)) {
       resolvedValue = processPayloadTemplate(value, json, context);

--- a/src/stateMachine/InputOutputProcessing.ts
+++ b/src/stateMachine/InputOutputProcessing.ts
@@ -1,4 +1,3 @@
-import type { PayloadTemplate } from '../typings/InputOutputProcessing';
 import type { JSONValue } from '../typings/JSONValue';
 import type { Context } from '../typings/Context';
 import { isPlainObj } from '../util';
@@ -34,7 +33,17 @@ function processInputPath(path: string | null | undefined, input: JSONValue, con
  * @param context The context object to evaluate, if the path expression starts with `$$`.
  * @returns The processed payload template.
  */
-function processPayloadTemplate(payloadTemplate: PayloadTemplate, json: JSONValue, context: Context): PayloadTemplate {
+function processPayloadTemplate(payloadTemplate: JSONValue, json: JSONValue, context: Context): JSONValue {
+  if (typeof payloadTemplate !== 'object' || payloadTemplate === null) {
+    // Processing a primitive value is not described in the spec, but allowed by the AWS implementation
+    return payloadTemplate;
+  }
+
+  if (Array.isArray(payloadTemplate)) {
+    // Processing an array value is not described in the spec, but allowed by the AWS implementation
+    return payloadTemplate.map((value) => processPayloadTemplate(value, json, context));
+  }
+
   const resolvedProperties = Object.entries(payloadTemplate).map(([key, value]) => {
     let sanitizedKey = key;
     let resolvedValue = value;

--- a/src/typings/InputOutputProcessing.ts
+++ b/src/typings/InputOutputProcessing.ts
@@ -1,17 +1,17 @@
-import type { JSONObject } from './JSONValue';
+import type { JSONArray, JSONObject, JSONValue } from './JSONValue';
 
-export type PayloadTemplate = JSONObject;
+export type PayloadTemplate = JSONObject | JSONArray;
 
 export interface CanHaveInputPath {
   InputPath?: string | null;
 }
 
 export interface CanHaveParameters {
-  Parameters?: PayloadTemplate;
+  Parameters?: JSONValue;
 }
 
 export interface CanHaveResultSelector {
-  ResultSelector?: PayloadTemplate;
+  ResultSelector?: JSONValue;
 }
 
 export interface CanHaveResultPath {


### PR DESCRIPTION
- Adds support for passing array or primitive values to `Parameters` and `ResultSelector` fields.
   > NOTE: This feature is not described by the spec, however AWS Step Functions does allow passing array and primitive values to these fields.

---

Resolves #81 