### PR TITLE
Chore/remove lodash

### DIFF
--- a/__tests__/cli/CLI.test.ts
+++ b/__tests__/cli/CLI.test.ts
@@ -82,8 +82,8 @@ describe('CLI', () => {
       });
 
       await expect(program.parseAsync(['-d', definition, '{}'], { from: 'user' })).rejects.toThrow();
-      expect(errStr).toBe(
-        "error: parsing of state machine definition passed in option '-d, --definition <definition>' failed: Unexpected token S in JSON at position 12\n"
+      expect(errStr).toMatch(
+        /^error: parsing of state machine definition passed in option '-d, --definition <definition>' failed:/
       );
     });
 
@@ -139,8 +139,8 @@ describe('CLI', () => {
       });
 
       await expect(program.parseAsync(['-f', filePath, '{}'], { from: 'user' })).rejects.toThrow();
-      expect(errStr).toBe(
-        "error: parsing of state machine definition in file './state-machine.asl.json' failed: Unexpected token S in JSON at position 12\n"
+      expect(errStr).toMatch(
+        /error: parsing of state machine definition in file '\.\/state-machine\.asl\.json' failed:/
       );
     });
 
@@ -168,9 +168,7 @@ describe('CLI', () => {
       });
 
       await expect(program.parseAsync(['-d', definition, input], { from: 'user' })).rejects.toThrow();
-      expect(errStr).toBe(
-        "error: parsing of input value '{ key: 123 }' failed: Unexpected token k in JSON at position 2\n"
-      );
+      expect(errStr).toMatch(/error: parsing of input value '{ key: 123 }' failed:/);
     });
 
     test('should print error when passing a definition that contains an invalid JSONPath', async () => {
@@ -542,7 +540,9 @@ describe('CLI', () => {
 
       expect(child_process.spawnSync).toHaveBeenCalled();
       expect(consoleLogMock).toHaveBeenCalledWith(
-        "Execution has failed with the following error: Parsing of output '{ key: value }' from task override './override.sh' for state 'AddNumbers' failed: Unexpected token k in JSON at position 2"
+        expect.stringMatching(
+          /Execution has failed with the following error: Parsing of output '{ key: value }' from task override '\.\/override\.sh' for state 'AddNumbers' failed:/
+        )
       );
     });
   });

--- a/__tests__/util/index.test.ts
+++ b/__tests__/util/index.test.ts
@@ -1,4 +1,5 @@
-import { isPlainObj, sleep, isRFC3339Timestamp } from '../../src/util';
+import { isPlainObj, sleep, isRFC3339Timestamp, cloneJSON, isEqualJSON, setJSONPath } from '../../src/util';
+import type { JSONValue } from '../../src/typings/JSONValue';
 
 afterEach(() => {
   jest.clearAllMocks();
@@ -105,6 +106,418 @@ describe('Utils', () => {
         const result = isRFC3339Timestamp(dateStr);
 
         expect(result).toBe(false);
+      });
+    });
+  });
+
+  describe('cloneJSON', () => {
+    describe('primitives', () => {
+      test('should return null as-is', () => {
+        expect(cloneJSON(null)).toBeNull();
+      });
+
+      test('should return boolean true as-is', () => {
+        expect(cloneJSON(true)).toBe(true);
+      });
+
+      test('should return boolean false as-is', () => {
+        expect(cloneJSON(false)).toBe(false);
+      });
+
+      test('should return number as-is', () => {
+        expect(cloneJSON(42)).toBe(42);
+      });
+
+      test('should return negative number as-is', () => {
+        expect(cloneJSON(-3.14)).toBe(-3.14);
+      });
+
+      test('should return zero as-is', () => {
+        expect(cloneJSON(0)).toBe(0);
+      });
+
+      test('should return string as-is', () => {
+        expect(cloneJSON('hello')).toBe('hello');
+      });
+
+      test('should return empty string as-is', () => {
+        expect(cloneJSON('')).toBe('');
+      });
+    });
+
+    describe('objects', () => {
+      test('should return a new object reference', () => {
+        const obj = { a: 1 };
+        expect(cloneJSON(obj)).not.toBe(obj);
+      });
+
+      test('should deep-clone an empty object', () => {
+        expect(cloneJSON({})).toEqual({});
+      });
+
+      test('should deep-clone a flat object', () => {
+        expect(cloneJSON({ a: 1, b: 'x', c: true, d: null })).toEqual({ a: 1, b: 'x', c: true, d: null });
+      });
+
+      test('should deep-clone a nested object', () => {
+        const obj = { a: { b: { c: 42 } } };
+        expect(cloneJSON(obj)).toEqual({ a: { b: { c: 42 } } });
+      });
+
+      test('should produce a deep clone such that mutating the clone does not affect the original', () => {
+        const obj: JSONValue = { a: { b: 1 } };
+        const clone = cloneJSON(obj) as { a: { b: number } };
+        clone.a.b = 999;
+        expect(obj).toEqual({ a: { b: 1 } });
+      });
+
+      test('should produce a deep clone such that mutating the original does not affect the clone', () => {
+        const obj: { a: { b: number } } = { a: { b: 1 } };
+        const clone = cloneJSON(obj);
+        obj.a.b = 999;
+        expect(clone).toEqual({ a: { b: 1 } });
+      });
+
+      test('should deep-clone object with array values', () => {
+        const obj = { nums: [1, 2, 3], nested: { flag: true } };
+        expect(cloneJSON(obj)).toEqual({ nums: [1, 2, 3], nested: { flag: true } });
+      });
+    });
+
+    describe('arrays', () => {
+      test('should return a new array reference', () => {
+        const arr = [1, 2, 3];
+        expect(cloneJSON(arr)).not.toBe(arr);
+      });
+
+      test('should deep-clone an empty array', () => {
+        expect(cloneJSON([])).toEqual([]);
+      });
+
+      test('should deep-clone a flat array', () => {
+        expect(cloneJSON([1, 'two', true, null])).toEqual([1, 'two', true, null]);
+      });
+
+      test('should deep-clone a nested array', () => {
+        expect(
+          cloneJSON([
+            [1, 2],
+            [3, [4, 5]],
+          ])
+        ).toEqual([
+          [1, 2],
+          [3, [4, 5]],
+        ]);
+      });
+
+      test('should produce a deep clone such that mutating the clone does not affect the original', () => {
+        const arr: JSONValue = [{ a: 1 }, { b: 2 }];
+        const clone = cloneJSON(arr) as Array<{ [key: string]: number }>;
+        clone[0]['a'] = 999;
+        expect(arr).toEqual([{ a: 1 }, { b: 2 }]);
+      });
+
+      test('should deep-clone an array of objects', () => {
+        expect(cloneJSON([{ a: 1 }, { b: [2, 3] }])).toEqual([{ a: 1 }, { b: [2, 3] }]);
+      });
+    });
+  });
+
+  describe('isEqualJSON', () => {
+    describe('null', () => {
+      test('should return true for null compared to null', () => {
+        expect(isEqualJSON(null, null)).toBe(true);
+      });
+
+      test('should return false for null compared to a number', () => {
+        expect(isEqualJSON(null, 0)).toBe(false);
+      });
+
+      test('should return false for null compared to a boolean', () => {
+        expect(isEqualJSON(null, false)).toBe(false);
+      });
+
+      test('should return false for null compared to an empty string', () => {
+        expect(isEqualJSON(null, '')).toBe(false);
+      });
+
+      test('should return false for null compared to an empty object', () => {
+        expect(isEqualJSON(null, {})).toBe(false);
+      });
+
+      test('should return false for null compared to an empty array', () => {
+        expect(isEqualJSON(null, [])).toBe(false);
+      });
+    });
+
+    describe('booleans', () => {
+      test('should return true for true compared to true', () => {
+        expect(isEqualJSON(true, true)).toBe(true);
+      });
+
+      test('should return true for false compared to false', () => {
+        expect(isEqualJSON(false, false)).toBe(true);
+      });
+
+      test('should return false for true compared to false', () => {
+        expect(isEqualJSON(true, false)).toBe(false);
+      });
+
+      test('should return false for false compared to 0', () => {
+        expect(isEqualJSON(false, 0)).toBe(false);
+      });
+    });
+
+    describe('numbers', () => {
+      test('should return true for equal numbers', () => {
+        expect(isEqualJSON(42, 42)).toBe(true);
+      });
+
+      test('should return true for equal negative numbers', () => {
+        expect(isEqualJSON(-3.14, -3.14)).toBe(true);
+      });
+
+      test('should return true for zero compared to zero', () => {
+        expect(isEqualJSON(0, 0)).toBe(true);
+      });
+
+      test('should return false for different numbers', () => {
+        expect(isEqualJSON(1, 2)).toBe(false);
+      });
+
+      test('should return false for number compared to its string representation', () => {
+        expect(isEqualJSON(1, '1')).toBe(false);
+      });
+    });
+
+    describe('strings', () => {
+      test('should return true for equal strings', () => {
+        expect(isEqualJSON('hello', 'hello')).toBe(true);
+      });
+
+      test('should return true for equal empty strings', () => {
+        expect(isEqualJSON('', '')).toBe(true);
+      });
+
+      test('should return false for different strings', () => {
+        expect(isEqualJSON('foo', 'bar')).toBe(false);
+      });
+
+      test('should return false for string compared to boolean', () => {
+        expect(isEqualJSON('true', true)).toBe(false);
+      });
+    });
+
+    describe('arrays', () => {
+      test('should return true for two empty arrays', () => {
+        expect(isEqualJSON([], [])).toBe(true);
+      });
+
+      test('should return true for two equal flat arrays', () => {
+        expect(isEqualJSON([1, 2, 3], [1, 2, 3])).toBe(true);
+      });
+
+      test('should return false for arrays with different lengths', () => {
+        expect(isEqualJSON([1, 2], [1, 2, 3])).toBe(false);
+      });
+
+      test('should return false for arrays with same elements in different order', () => {
+        expect(isEqualJSON([1, 2, 3], [1, 3, 2])).toBe(false);
+      });
+
+      test('should return true for equal nested arrays', () => {
+        expect(
+          isEqualJSON(
+            [
+              [1, 2],
+              [3, 4],
+            ],
+            [
+              [1, 2],
+              [3, 4],
+            ]
+          )
+        ).toBe(true);
+      });
+
+      test('should return false for arrays where a nested element differs', () => {
+        expect(
+          isEqualJSON(
+            [
+              [1, 2],
+              [3, 4],
+            ],
+            [
+              [1, 2],
+              [3, 5],
+            ]
+          )
+        ).toBe(false);
+      });
+
+      test('should return true for arrays containing equal objects', () => {
+        expect(isEqualJSON([{ a: 1 }, { b: 2 }], [{ a: 1 }, { b: 2 }])).toBe(true);
+      });
+
+      test('should return false for arrays containing objects that differ', () => {
+        expect(isEqualJSON([{ a: 1 }], [{ a: 2 }])).toBe(false);
+      });
+
+      test('should return false for an array compared to an object', () => {
+        expect(isEqualJSON([], {})).toBe(false);
+      });
+    });
+
+    describe('objects', () => {
+      test('should return true for two empty objects', () => {
+        expect(isEqualJSON({}, {})).toBe(true);
+      });
+
+      test('should return true for two equal flat objects', () => {
+        expect(isEqualJSON({ a: 1, b: 'x' }, { a: 1, b: 'x' })).toBe(true);
+      });
+
+      test('should return false for objects with different values', () => {
+        expect(isEqualJSON({ a: 1 }, { a: 2 })).toBe(false);
+      });
+
+      test('should return false for objects with different keys', () => {
+        expect(isEqualJSON({ a: 1 }, { b: 1 })).toBe(false);
+      });
+
+      test('should return false for objects with different number of keys', () => {
+        expect(isEqualJSON({ a: 1, b: 2 }, { a: 1 })).toBe(false);
+      });
+
+      test('should return true regardless of key insertion order', () => {
+        expect(isEqualJSON({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true);
+      });
+
+      test('should return true for equal nested objects', () => {
+        expect(isEqualJSON({ a: { b: { c: 1 } } }, { a: { b: { c: 1 } } })).toBe(true);
+      });
+
+      test('should return false for nested objects where a deep value differs', () => {
+        expect(isEqualJSON({ a: { b: 1 } }, { a: { b: 2 } })).toBe(false);
+      });
+
+      test('should return true for objects with equal array values', () => {
+        expect(isEqualJSON({ a: [1, 2, 3] }, { a: [1, 2, 3] })).toBe(true);
+      });
+
+      test('should return false for objects with differing array values', () => {
+        expect(isEqualJSON({ a: [1, 2, 3] }, { a: [1, 2, 4] })).toBe(false);
+      });
+
+      test('should return true for objects with null values', () => {
+        expect(isEqualJSON({ a: null }, { a: null })).toBe(true);
+      });
+
+      test('should return false for object compared to null', () => {
+        expect(isEqualJSON({}, null)).toBe(false);
+      });
+    });
+  });
+
+  describe('setJSONPath', () => {
+    describe('dot notation', () => {
+      test('should set a top-level key on an empty object', () => {
+        expect(setJSONPath({}, 'foo', 42)).toEqual({ foo: 42 });
+      });
+
+      test('should set a nested key using dot notation', () => {
+        expect(setJSONPath({}, 'foo.bar', 42)).toEqual({ foo: { bar: 42 } });
+      });
+
+      test('should set a deeply nested key using dot notation', () => {
+        expect(setJSONPath({}, 'a.b.c.d', 42)).toEqual({ a: { b: { c: { d: 42 } } } });
+      });
+
+      test('should overwrite an existing top-level key', () => {
+        expect(setJSONPath({ foo: 1 }, 'foo', 2)).toEqual({ foo: 2 });
+      });
+
+      test('should overwrite an existing nested key', () => {
+        expect(setJSONPath({ foo: { bar: 1 } }, 'foo.bar', 2)).toEqual({ foo: { bar: 2 } });
+      });
+
+      test('should preserve sibling keys when setting a top-level key', () => {
+        expect(setJSONPath({ a: 1, b: 2 }, 'a', 3)).toEqual({ a: 3, b: 2 });
+      });
+
+      test('should preserve sibling keys when setting a nested key', () => {
+        expect(setJSONPath({ foo: { a: 1, b: 2 } }, 'foo.a', 3)).toEqual({ foo: { a: 3, b: 2 } });
+      });
+    });
+
+    describe('bracket notation', () => {
+      test('should set a key using single-quote bracket notation', () => {
+        expect(setJSONPath({}, "foo['bar']", 42)).toEqual({ foo: { bar: 42 } });
+      });
+
+      test('should set a key using double-quote bracket notation', () => {
+        expect(setJSONPath({}, 'foo["bar"]', 42)).toEqual({ foo: { bar: 42 } });
+      });
+    });
+
+    describe('array index notation', () => {
+      test('should set an element in an existing array by index', () => {
+        expect(setJSONPath({ arr: [1, 2, 3] }, 'arr[1]', 99)).toEqual({ arr: [1, 99, 3] });
+      });
+
+      test('should create an array and set an element by index', () => {
+        expect(setJSONPath({}, 'arr[0]', 42)).toEqual({ arr: [42] });
+      });
+    });
+
+    describe('mixed notation', () => {
+      test('should handle a mix of dot notation and array index', () => {
+        expect(setJSONPath({}, 'foo.bar[0].baz', 42)).toEqual({ foo: { bar: [{ baz: 42 }] } });
+      });
+
+      test('should handle a mix of dot notation and bracket notation', () => {
+        expect(setJSONPath({}, "foo['bar'].baz", 42)).toEqual({ foo: { bar: { baz: 42 } } });
+      });
+    });
+
+    describe('value types', () => {
+      test('should set a null value', () => {
+        expect(setJSONPath({}, 'foo', null)).toEqual({ foo: null });
+      });
+
+      test('should set a string value', () => {
+        expect(setJSONPath({}, 'foo', 'hello')).toEqual({ foo: 'hello' });
+      });
+
+      test('should set a boolean value', () => {
+        expect(setJSONPath({}, 'foo', true)).toEqual({ foo: true });
+      });
+
+      test('should set an array value', () => {
+        expect(setJSONPath({}, 'foo', [1, 2, 3])).toEqual({ foo: [1, 2, 3] });
+      });
+
+      test('should set an object value', () => {
+        expect(setJSONPath({}, 'foo', { a: 1 })).toEqual({ foo: { a: 1 } });
+      });
+    });
+
+    describe('immutability', () => {
+      test('should not mutate the original object', () => {
+        const original = { a: 1 };
+        setJSONPath(original, 'a', 2);
+        expect(original).toEqual({ a: 1 });
+      });
+
+      test('should not mutate deeply nested objects in the original', () => {
+        const original = { foo: { bar: 1 } };
+        setJSONPath(original, 'foo.bar', 2);
+        expect(original).toEqual({ foo: { bar: 1 } });
+      });
+
+      test('should return a new object reference', () => {
+        const original = { a: 1 };
+        expect(setJSONPath(original, 'a', 2)).not.toBe(original);
       });
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,7 @@
         "@aws-sdk/credential-providers": "^3.693.0",
         "asl-validator": "^3.9.0",
         "commander": "^11.1.0",
-        "jsonpath-plus": "^10.2.0",
-        "lodash": "^4.17.21",
+        "jsonpath-plus": "^10.4.0",
         "p-limit": "^3.1.0",
         "wildcard-match": "^5.1.3"
       },
@@ -23,8 +22,7 @@
       },
       "devDependencies": {
         "@types/jest": "^29.5.14",
-        "@types/lodash": "^4.17.13",
-        "@types/node": "^18.19.64",
+        "@types/node": "^18.19.130",
         "@typescript-eslint/eslint-plugin": "^6.21.0",
         "@typescript-eslint/parser": "^6.21.0",
         "eslint": "^8.57.1",
@@ -3622,17 +3620,12 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true
     },
-    "node_modules/@types/lodash": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.13.tgz",
-      "integrity": "sha512-lfx+dftrEZcdBPczf9d0Qv0x+j/rfNCMuC6OcfXmO8gkfeNAY88PgKUbvG56whcN23gc27yenwF6oJZXGFpYxg==",
-      "dev": true
-    },
     "node_modules/@types/node": {
-      "version": "18.19.64",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.64.tgz",
-      "integrity": "sha512-955mDqvO2vFf/oL7V3WiUtiz+BugyX8uVbaT2H8oj3+8dRyH2FLiNdowe7eNqRM7IOIZvzDH76EoAT+gwm6aIQ==",
+      "version": "18.19.130",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.130.tgz",
+      "integrity": "sha512-GRaXQx6jGfL8sKfaIDD6OupbIHBr9jv7Jnaml9tB7l4v068PAOXqfcujMMo5PhbIs6ggR1XODELqahT2R8v0fg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -6457,11 +6450,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.memoize": {
       "version": "4.1.2",

--- a/package.json
+++ b/package.json
@@ -54,8 +54,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.5.14",
-    "@types/lodash": "^4.17.13",
-    "@types/node": "^18.19.64",
+    "@types/node": "^18.19.130",
     "@typescript-eslint/eslint-plugin": "^6.21.0",
     "@typescript-eslint/parser": "^6.21.0",
     "eslint": "^8.57.1",
@@ -71,8 +70,7 @@
     "@aws-sdk/credential-providers": "^3.693.0",
     "asl-validator": "^3.9.0",
     "commander": "^11.1.0",
-    "jsonpath-plus": "^10.2.0",
-    "lodash": "^4.17.21",
+    "jsonpath-plus": "^10.4.0",
     "p-limit": "^3.1.0",
     "wildcard-match": "^5.1.3"
   }

--- a/src/stateMachine/InputOutputProcessing.ts
+++ b/src/stateMachine/InputOutputProcessing.ts
@@ -1,11 +1,9 @@
 import type { JSONValue } from '../typings/JSONValue';
 import type { Context } from '../typings/Context';
-import { isPlainObj } from '../util';
+import { isPlainObj, setJSONPath } from '../util';
 import { jsonPathQuery } from './jsonPath/JsonPath';
 import { StatesResultPathMatchFailureError } from '../error/predefined/StatesResultPathMatchFailureError';
 import { evaluateIntrinsicFunction } from './IntrinsicFunctionEvaluation';
-import cloneDeep from 'lodash/cloneDeep.js';
-import set from 'lodash/set.js';
 
 /**
  * Process the current input according to the path defined in the `InputPath` field, if specified in the current state.
@@ -98,8 +96,7 @@ function processResultPath(path: string | null | undefined, rawInput: JSONValue,
   const sanitizedPath = path.replace('$.', '');
 
   if (isPlainObj(rawInput)) {
-    const clonedRawInput = cloneDeep(rawInput);
-    return set(clonedRawInput, sanitizedPath, result);
+    return setJSONPath(rawInput, sanitizedPath, result);
   }
 
   throw new StatesResultPathMatchFailureError();

--- a/src/stateMachine/StateExecutor.ts
+++ b/src/stateMachine/StateExecutor.ts
@@ -29,8 +29,7 @@ import { SucceedStateAction } from './stateActions/SucceedStateAction';
 import { TaskStateAction } from './stateActions/TaskStateAction';
 import { WaitStateAction } from './stateActions/WaitStateAction';
 import { StatesTimeoutError } from '../error/predefined/StatesTimeoutError';
-import { clamp, sleep, getRandomNumber } from '../util';
-import cloneDeep from 'lodash/cloneDeep.js';
+import { clamp, sleep, getRandomNumber, cloneJSON } from '../util';
 
 /**
  * Default max number of attempts to retry each retrier.
@@ -111,7 +110,7 @@ export class StateExecutor {
    * Execute the current state.
    */
   async execute(input: JSONValue, context: Context, options: ExecuteOptions): Promise<ActionResult> {
-    const rawInput = cloneDeep(input);
+    const rawInput = cloneJSON(input);
 
     try {
       const processedInput = this.processInput(input, context);

--- a/src/stateMachine/StateMachine.ts
+++ b/src/stateMachine/StateMachine.ts
@@ -8,8 +8,8 @@ import { ExecutionTimeoutError } from '../error/ExecutionTimeoutError';
 import { ExecutionError } from '../error/ExecutionError';
 import { StateExecutor } from './StateExecutor';
 import { EventLogger } from './EventLogger';
+import { cloneJSON } from '../util';
 import aslValidator from 'asl-validator';
-import cloneDeep from 'lodash/cloneDeep.js';
 
 export class StateMachine {
   /**
@@ -154,7 +154,7 @@ export class StateMachine {
     };
     let currState = this.definition.States[this.definition.StartAt];
     let currStateName = this.definition.StartAt;
-    let currInput = cloneDeep(input);
+    let currInput = cloneJSON(input);
     let currResult: JSONValue = null;
     let nextState = '';
     let isEndState = false;

--- a/src/stateMachine/intrinsicFunctions/StatesArrayContains.ts
+++ b/src/stateMachine/intrinsicFunctions/StatesArrayContains.ts
@@ -1,7 +1,7 @@
 import type { IntrinsicFunctionDefinition } from '../../typings/IntrinsicFunctionsImplementation';
 import type { JSONValue } from '../../typings/JSONValue';
 import { BaseIntrinsicFunction } from './BaseIntrinsicFunction';
-import isEqual from 'lodash/isEqual.js';
+import { isEqualJSON } from '../../util';
 
 class StatesArrayContains extends BaseIntrinsicFunction {
   protected readonly funcDefinition: IntrinsicFunctionDefinition;
@@ -24,7 +24,7 @@ class StatesArrayContains extends BaseIntrinsicFunction {
   }
 
   protected execute(array: JSONValue[], searchVal: JSONValue): JSONValue {
-    return array.findIndex((val) => isEqual(val, searchVal)) > -1;
+    return array.findIndex((val) => isEqualJSON(val, searchVal)) > -1;
   }
 }
 

--- a/src/stateMachine/intrinsicFunctions/StatesArrayUnique.ts
+++ b/src/stateMachine/intrinsicFunctions/StatesArrayUnique.ts
@@ -1,8 +1,7 @@
 import type { IntrinsicFunctionDefinition } from '../../typings/IntrinsicFunctionsImplementation';
 import type { JSONValue } from '../../typings/JSONValue';
 import { BaseIntrinsicFunction } from './BaseIntrinsicFunction';
-import isEqual from 'lodash/isEqual.js';
-import uniqWith from 'lodash/uniqWith.js';
+import { isEqualJSON } from '../../util';
 
 class StatesArrayUnique extends BaseIntrinsicFunction {
   protected readonly funcDefinition: IntrinsicFunctionDefinition;
@@ -22,7 +21,7 @@ class StatesArrayUnique extends BaseIntrinsicFunction {
   }
 
   protected execute(array: JSONValue[]): JSONValue {
-    return uniqWith(array, isEqual);
+    return array.filter((val, i) => array.findIndex((other) => isEqualJSON(val, other)) === i);
   }
 }
 

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,4 +1,4 @@
-import type { JSONObject } from '../typings/JSONValue';
+import type { JSONObject, JSONValue } from '../typings/JSONValue';
 
 export const isBrowserEnvironment = typeof window !== 'undefined' && typeof window.document !== 'undefined';
 
@@ -77,6 +77,98 @@ export function clamp(value: number, min: number | undefined, max: number | unde
   if (min && value < min) return min;
   if (max && value > max) return max;
   return value;
+}
+
+/**
+ * Recursively deep-clones a JSON value, producing a new value with no shared references.
+ */
+export function cloneJSON(value: JSONValue): JSONValue {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(cloneJSON);
+  return Object.fromEntries(Object.entries(value).map(([k, v]) => [k, cloneJSON(v)]));
+}
+
+/**
+ * Recursively compares two JSON values for deep equality.
+ * Comparison is independent of key order for objects.
+ */
+export function isEqualJSON(a: JSONValue, b: JSONValue): boolean {
+  if (a === b) return true;
+  if (a === null || b === null) return false;
+  if (typeof a !== 'object' || typeof b !== 'object') return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => isEqualJSON(v, b[i]));
+  }
+  const aObj = a as JSONObject;
+  const bObj = b as JSONObject;
+  const aKeys = Object.keys(aObj);
+  const bKeys = Object.keys(bObj);
+  if (aKeys.length !== bKeys.length) return false;
+  return aKeys.every((k) => Object.prototype.hasOwnProperty.call(bObj, k) && isEqualJSON(aObj[k], bObj[k]));
+}
+
+/**
+ * Sets a value at a path in a JSON object, returning a new object without mutating the original.
+ * Handles dot notation (foo.bar), bracket notation (foo['bar'], foo["bar"]), and array indices (foo[0]).
+ */
+export function setJSONPath(obj: JSONObject, path: string, value: JSONValue): JSONObject {
+  function parseSegments(p: string): (string | number)[] {
+    const segments: (string | number)[] = [];
+    let current = '';
+    let i = 0;
+    while (i < p.length) {
+      const ch = p[i];
+      if (ch === '.') {
+        if (current.length > 0) {
+          segments.push(current);
+          current = '';
+        }
+        i++;
+      } else if (ch === '[') {
+        if (current.length > 0) {
+          segments.push(current);
+          current = '';
+        }
+        i++; // skip '['
+        const quote = p[i];
+        if (quote === '"' || quote === "'") {
+          i++; // skip opening quote
+          while (i < p.length && p[i] !== quote) current += p[i++];
+          i++; // skip closing quote
+          segments.push(current);
+        } else {
+          while (i < p.length && p[i] !== ']') current += p[i++];
+          segments.push(parseInt(current, 10));
+        }
+        current = '';
+        i++; // skip ']'
+      } else {
+        current += ch;
+        i++;
+      }
+    }
+    if (current.length > 0) segments.push(current);
+    return segments;
+  }
+
+  function setAtSegments(target: JSONValue, segments: (string | number)[]): JSONValue {
+    if (segments.length === 0) return value;
+    const [head, ...tail] = segments;
+    if (typeof head === 'number') {
+      const arr: JSONValue[] = Array.isArray(target) ? [...(target as JSONValue[])] : [];
+      arr[head] = setAtSegments(arr[head] !== undefined ? arr[head] : null, tail);
+      return arr;
+    }
+    const o: JSONObject =
+      typeof target === 'object' && target !== null && !Array.isArray(target) ? { ...(target as JSONObject) } : {};
+    const existing = (o as Record<string, JSONValue>)[head];
+    o[head] = setAtSegments(existing !== undefined ? existing : null, tail);
+    return o;
+  }
+
+  return setAtSegments(obj, parseSegments(path)) as JSONObject;
 }
 
 export { getRandomNumber, sfc32, cyrb128 } from './random';


### PR DESCRIPTION
- Removes dependency on `lodash`, by implementing the lodash functions used in this library with custom util functions. Namely, replaces `isEqual`, `cloneDeep`, and `set` with `isEqualJSON`, `cloneJSON`, and `setJSONPath`.
- Adds tests cases for the new util functions
- Updates CLI test matchers to not check for changes in `JSON.parse` error messages, that may change depending on the Node version