### PR TITLE
Attempted release 3.0.0

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -5,6 +5,10 @@ on:
     types:
       - published
 
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
 jobs:
@@ -24,5 +28,3 @@ jobs:
         run: npm run build
       - name: Publish to NPM
         run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
> This release is a breaking change, as the package now requires Node version to be >=22.

### Lodash removal

#104

### Upgrade to Node 22

#105

## UPDATE

This was missing the change in #108 for the OIDC trusted publishing to be able to publish the package to NPM.