### PR TITLE
Attempted release 3.0.0

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -20,6 +20,8 @@ jobs:
         with:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
+      - name: Upgrade npm
+        run: npm install -g npm@^11.5.1 # 11.5.1+ is required for OIDC trusted publishing (tokenless authentication)
       - name: Install dependencies
         run: npm ci
       - name: Run tests


### PR DESCRIPTION
> This release is a breaking change, as the package now requires Node version to be >=22.

### Lodash removal

#104

### Upgrade to Node 22

#105

## UPDATE

This was missing the change in #109 for the OIDC trusted publishing to be able to publish the package to NPM. Specifically, it needed to install `npm v11.5.1` directly from npmjs, instead of using npm to upgrade itself